### PR TITLE
Add onboarding wizard for first-time setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,31 @@ src/
 - shadcn/ui components in `src/components/ui/`
 - Color palette for users: blue, red, green, amber, violet, pink, cyan, orange
 
+### Testing
+
+**All new features must include both unit and e2e tests.**
+
+- **Unit tests** (Vitest): `src/app/api/__tests__/*.test.ts`
+  - Use in-memory SQLite via `better-sqlite3` for isolation
+  - Mock `@/lib/db` with `vi.mock()` to inject test DB
+  - Import and call route handlers directly as functions
+  - Create tables with raw SQL in `createTables()`, reset per test via `beforeEach`
+  - Use helper functions for HTTP request construction and test data insertion
+
+- **E2e tests** (Playwright): `e2e/*.spec.ts`
+  - Use `test.describe.serial()` for sequential test groups
+  - Isolate test data with timestamped names: `` `E2E Test Foo ${Date.now()}` ``
+  - Clean up via `cleanupTestData(request, type, pattern)` in `test.afterAll()`
+  - Handle user picker dialog with `dismissUserPickerIfVisible(page)` helper
+  - Wait for `networkidle` and loading states before assertions
+  - Cleanup endpoint: `POST /api/e2e-cleanup` (dev-only)
+
+### Dark Mode
+- Class-based Tailwind v4 dark mode with `@custom-variant dark`
+- Three modes: light, dark, system (stored in localStorage as `"tuis-theme"`)
+- ThemeProvider in layout.tsx applies `.dark` class on `document.documentElement`
+- Use `dark:` variant for all hardcoded color classes (e.g. `bg-gray-50 dark:bg-zinc-800`)
+
 ## Commands
 ```bash
 npm run dev          # Start dev server

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# Tuis - Household Management App
+
+## Overview
+Tuis (Afrikaans for "at home") is a self-hosted household management web app built with Next.js. It handles chores, meal planning, shopping lists, recipes, appliance tracking, vendor management, quotes, and couple activities.
+
+## Tech Stack
+- **Framework**: Next.js 16 (App Router)
+- **Language**: TypeScript
+- **Database**: SQLite via better-sqlite3 + Drizzle ORM
+- **Styling**: Tailwind CSS v4 + shadcn/ui components
+- **Icons**: lucide-react
+
+## Project Structure
+```
+src/
+  app/              # Next.js App Router pages and API routes
+    api/            # REST API endpoints
+    setup/          # Onboarding wizard for first-time setup
+  components/
+    ui/             # shadcn/ui primitives (button, card, dialog, etc.)
+    layout/         # AppLayout, BottomNav
+    user-identity/  # UserPicker, UserAvatar
+    dashboard/      # Dashboard widgets
+    settings/       # Settings page components
+  lib/
+    db/             # Database connection (index.ts), schema (schema.ts), seeds
+    user-identity.tsx  # User identity context provider
+    utils.ts        # cn() utility
+```
+
+## Key Patterns
+
+### Pages
+- Pages use `AppLayout` component for consistent navigation (sidebar + mobile bottom nav)
+- Client pages use `"use client"` directive
+- Server pages can do direct DB access via `import { db } from "@/lib/db"`
+
+### API Routes
+- Located in `src/app/api/`
+- Use `NextResponse.json()` for responses
+- Import `db` from `@/lib/db` and schema from `@/lib/db/schema`
+- Mark dynamic routes with `export const dynamic = "force-dynamic"`
+
+### Database
+- SQLite file at `chore-calendar.db` (or `/app/data/chore-calendar.db` in Docker)
+- Schema defined in `src/lib/db/schema.ts` using Drizzle ORM
+- Table creation and migrations handled in `src/lib/db/index.ts`
+- Lazy initialization via Proxy pattern
+
+### User Identity
+- No auth - users are household members identified by localStorage selection
+- `UserIdentityProvider` wraps the app in layout.tsx
+- `useCurrentUser()` hook for accessing current user
+
+### UI Components
+- shadcn/ui components in `src/components/ui/`
+- Color palette for users: blue, red, green, amber, violet, pink, cyan, orange
+
+## Commands
+```bash
+npm run dev          # Start dev server
+npm run build        # Production build
+npm run seed         # Seed database
+npm run seed:demo    # Seed demo data
+npm run db:studio    # Drizzle Kit studio
+npm test             # Run vitest tests
+npm run test:e2e     # Run Playwright tests
+```
+
+## Deployment
+- Dockerised, pushed to local Gitea registry via `.gitea/workflows/build.yml`
+- Runs on homeserver at chores.home.lukeboyle.com

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -1,84 +1,135 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, APIRequestContext } from "@playwright/test";
 import { cleanupTestData } from "./cleanup";
 
 const TEST_USER_PREFIX = "E2E Setup User";
 const TEST_USER_NAME = `${TEST_USER_PREFIX} ${Date.now()}`;
 
-test.afterAll(async ({ request }) => {
-  // Clean up test users, seeded data
-  await cleanupTestData(request, "users", `${TEST_USER_PREFIX}%`);
-  await cleanupTestData(request, "tasks", "Wash dishes");
-  await cleanupTestData(request, "tasks", "Wipe kitchen counters");
-  await cleanupTestData(request, "tasks", "Clean stovetop");
-  await cleanupTestData(request, "tasks", "Clean oven");
-  await cleanupTestData(request, "tasks", "Clean fridge");
-  await cleanupTestData(request, "tasks", "Empty bins");
-  await cleanupTestData(request, "tasks", "Clean toilet");
-  await cleanupTestData(request, "tasks", "Clean shower/bath");
-  await cleanupTestData(request, "tasks", "Clean bathroom sink");
-  await cleanupTestData(request, "tasks", "Wash towels");
-  await cleanupTestData(request, "tasks", "Change bed sheets");
-  await cleanupTestData(request, "tasks", "Vacuum bedroom");
-  await cleanupTestData(request, "tasks", "Dust surfaces");
-  await cleanupTestData(request, "tasks", "Vacuum living room");
-  await cleanupTestData(request, "tasks", "Mop floors");
-  await cleanupTestData(request, "tasks", "Dust shelves");
-  await cleanupTestData(request, "tasks", "Mow lawn");
-  await cleanupTestData(request, "tasks", "Water garden");
-  await cleanupTestData(request, "tasks", "Sweep porch/patio");
-  await cleanupTestData(request, "tasks", "Do laundry");
-  await cleanupTestData(request, "tasks", "Iron clothes");
-  await cleanupTestData(request, "shopping", "Groceries");
-  await cleanupTestData(request, "recipes", "Pasta Bolognese");
-  await cleanupTestData(request, "recipes", "Chicken Stir-Fry");
-  await cleanupTestData(request, "recipes", "Scrambled Eggs on Toast");
-});
+// Store existing users so we can restore them after tests
+let existingUsers: Array<{ name: string; color: string }> = [];
+
+async function backupAndClearUsers(request: APIRequestContext) {
+  // Fetch existing users
+  const res = await request.get("/api/users");
+  if (res.ok()) {
+    existingUsers = await res.json();
+  }
+  // Delete all users to simulate fresh install
+  if (existingUsers.length > 0) {
+    await cleanupTestData(request, "users", "%");
+  }
+}
+
+async function restoreUsers(request: APIRequestContext) {
+  // Re-create the original users
+  for (const user of existingUsers) {
+    await request.post("/api/users", {
+      data: { name: user.name, color: user.color },
+    });
+  }
+}
 
 test.describe.serial("Setup Wizard", () => {
-  test("GET /api/setup returns needsSetup status", async ({ request }) => {
+  test.beforeAll(async ({ request }) => {
+    // Clean up any leftover seed data from prior runs
+    await cleanupTestData(request, "tasks", "Wash dishes");
+    await cleanupTestData(request, "tasks", "Wipe kitchen counters");
+    await cleanupTestData(request, "tasks", "Clean stovetop");
+    await cleanupTestData(request, "tasks", "Clean oven");
+    await cleanupTestData(request, "tasks", "Clean fridge");
+    await cleanupTestData(request, "tasks", "Empty bins");
+    await cleanupTestData(request, "tasks", "Clean toilet");
+    await cleanupTestData(request, "tasks", "Clean shower/bath");
+    await cleanupTestData(request, "tasks", "Clean bathroom sink");
+    await cleanupTestData(request, "tasks", "Wash towels");
+    await cleanupTestData(request, "tasks", "Change bed sheets");
+    await cleanupTestData(request, "tasks", "Vacuum bedroom");
+    await cleanupTestData(request, "tasks", "Dust surfaces");
+    await cleanupTestData(request, "tasks", "Vacuum living room");
+    await cleanupTestData(request, "tasks", "Mop floors");
+    await cleanupTestData(request, "tasks", "Dust shelves");
+    await cleanupTestData(request, "tasks", "Mow lawn");
+    await cleanupTestData(request, "tasks", "Water garden");
+    await cleanupTestData(request, "tasks", "Sweep porch/patio");
+    await cleanupTestData(request, "tasks", "Do laundry");
+    await cleanupTestData(request, "tasks", "Iron clothes");
+    await cleanupTestData(request, "shopping", "Groceries");
+    await cleanupTestData(request, "recipes", "Pasta Bolognese");
+    await cleanupTestData(request, "recipes", "Chicken Stir-Fry");
+    await cleanupTestData(request, "recipes", "Scrambled Eggs on Toast");
+
+    await backupAndClearUsers(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Clean up test user and seeded data
+    await cleanupTestData(request, "users", `${TEST_USER_PREFIX}%`);
+    await cleanupTestData(request, "tasks", "Wash dishes");
+    await cleanupTestData(request, "tasks", "Wipe kitchen counters");
+    await cleanupTestData(request, "tasks", "Clean stovetop");
+    await cleanupTestData(request, "tasks", "Clean oven");
+    await cleanupTestData(request, "tasks", "Clean fridge");
+    await cleanupTestData(request, "tasks", "Empty bins");
+    await cleanupTestData(request, "tasks", "Clean toilet");
+    await cleanupTestData(request, "tasks", "Clean shower/bath");
+    await cleanupTestData(request, "tasks", "Clean bathroom sink");
+    await cleanupTestData(request, "tasks", "Wash towels");
+    await cleanupTestData(request, "tasks", "Change bed sheets");
+    await cleanupTestData(request, "tasks", "Vacuum bedroom");
+    await cleanupTestData(request, "tasks", "Dust surfaces");
+    await cleanupTestData(request, "tasks", "Vacuum living room");
+    await cleanupTestData(request, "tasks", "Mop floors");
+    await cleanupTestData(request, "tasks", "Dust shelves");
+    await cleanupTestData(request, "tasks", "Mow lawn");
+    await cleanupTestData(request, "tasks", "Water garden");
+    await cleanupTestData(request, "tasks", "Sweep porch/patio");
+    await cleanupTestData(request, "tasks", "Do laundry");
+    await cleanupTestData(request, "tasks", "Iron clothes");
+    await cleanupTestData(request, "shopping", "Groceries");
+    await cleanupTestData(request, "recipes", "Pasta Bolognese");
+    await cleanupTestData(request, "recipes", "Chicken Stir-Fry");
+    await cleanupTestData(request, "recipes", "Scrambled Eggs on Toast");
+
+    // Restore original users
+    await restoreUsers(request);
+  });
+
+  test("GET /api/setup returns needsSetup: true with empty DB", async ({
+    request,
+  }) => {
     const res = await request.get("/api/setup");
     expect(res.ok()).toBeTruthy();
     const data = await res.json();
-    expect(data).toHaveProperty("needsSetup");
-    expect(typeof data.needsSetup).toBe("boolean");
+    expect(data.needsSetup).toBe(true);
   });
 
-  test("setup page loads and shows welcome step", async ({ page }) => {
+  test("setup page shows welcome step", async ({ page }) => {
     await page.goto("/setup");
     await page.waitForLoadState("networkidle");
 
-    // Should show the welcome screen (or redirect if setup not needed)
-    // Check for either the welcome heading or the dashboard
-    const welcomeHeading = page.getByRole("heading", {
-      name: "Welcome to Tuis",
-    });
-    const isSetupPage = await welcomeHeading.isVisible().catch(() => false);
-
-    if (isSetupPage) {
-      await expect(welcomeHeading).toBeVisible();
-      await expect(
-        page.getByRole("button", { name: "Get Started" })
-      ).toBeVisible();
-    }
-    // If not visible, setup was already done — page redirected to dashboard
+    await expect(
+      page.getByRole("heading", { name: "Welcome to Tuis" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Get Started" })
+    ).toBeVisible();
   });
 
-  test("setup wizard navigates through all steps", async ({ page }) => {
+  test("root page redirects to /setup when no users exist", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await expect(page).toHaveURL("/setup", { timeout: 5000 });
+  });
+
+  test("wizard navigates through all 4 steps", async ({ page }) => {
     await page.goto("/setup");
     await page.waitForLoadState("networkidle");
-
-    const welcomeHeading = page.getByRole("heading", {
-      name: "Welcome to Tuis",
-    });
-    const isSetupPage = await welcomeHeading.isVisible().catch(() => false);
-
-    // Only run the full wizard flow if setup is actually needed
-    if (!isSetupPage) {
-      test.skip();
-      return;
-    }
 
     // Step 0: Welcome → Click Get Started
+    await expect(
+      page.getByRole("heading", { name: "Welcome to Tuis" })
+    ).toBeVisible();
     await page.getByRole("button", { name: "Get Started" }).click();
 
     // Step 1: Members → Should show "Who lives here?"
@@ -97,7 +148,7 @@ test.describe.serial("Setup Wizard", () => {
     // Click Continue
     await page.getByRole("button", { name: "Continue" }).click();
 
-    // Step 2: Quick Start → Should show checkboxes
+    // Step 2: Quick Start → Should show seed options
     await expect(
       page.getByRole("heading", { name: "Quick Start" })
     ).toBeVisible();
@@ -105,7 +156,7 @@ test.describe.serial("Setup Wizard", () => {
     await expect(page.getByText("Sample shopping list")).toBeVisible();
     await expect(page.getByText("Sample recipes")).toBeVisible();
 
-    // Click Back to verify navigation
+    // Click Back to verify navigation works
     await page.getByRole("button", { name: "Back" }).click();
     await expect(
       page.getByRole("heading", { name: "Who lives here?" })
@@ -117,17 +168,13 @@ test.describe.serial("Setup Wizard", () => {
       page.getByRole("heading", { name: "Quick Start" })
     ).toBeVisible();
 
-    // Click Finish Setup
-    const responsePromise = page.waitForResponse(
-      (res) => res.url().includes("/api/users") && res.status() === 200
-    );
+    // Click Finish Setup and wait for completion
     await page.getByRole("button", { name: "Finish Setup" }).click();
-    await responsePromise;
 
     // Step 3: Done → Should show success
     await expect(
       page.getByRole("heading", { name: /all set/i })
-    ).toBeVisible({ timeout: 10000 });
+    ).toBeVisible({ timeout: 30000 });
     await expect(
       page.getByRole("button", { name: "Go to Dashboard" })
     ).toBeVisible();
@@ -140,22 +187,11 @@ test.describe.serial("Setup Wizard", () => {
     await expect(page).toHaveURL("/");
   });
 
-  test("POST /api/setup returns 409 after setup is complete", async ({
-    request,
+  test("visiting /setup after completion redirects to dashboard", async ({
+    page,
   }) => {
-    // Setup is now complete (user was created in previous test)
-    const res = await request.post("/api/setup", {
-      data: { seedChores: true, seedShopping: true, seedRecipes: true },
-    });
-    // Should return 409 since users now exist
-    expect(res.status()).toBe(409);
-  });
-
-  test("visiting /setup after completion redirects away", async ({ page }) => {
     await page.goto("/setup");
     await page.waitForLoadState("networkidle");
-
-    // Should have been redirected to the dashboard
     await expect(page).toHaveURL("/", { timeout: 5000 });
   });
 });

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, Page } from "@playwright/test";
+import { cleanupTestData } from "./cleanup";
+
+const TEST_USER_PREFIX = "E2E Setup User";
+const TEST_USER_NAME = `${TEST_USER_PREFIX} ${Date.now()}`;
+
+test.afterAll(async ({ request }) => {
+  // Clean up test users, seeded data
+  await cleanupTestData(request, "users", `${TEST_USER_PREFIX}%`);
+  await cleanupTestData(request, "tasks", "Wash dishes");
+  await cleanupTestData(request, "tasks", "Wipe kitchen counters");
+  await cleanupTestData(request, "tasks", "Clean stovetop");
+  await cleanupTestData(request, "tasks", "Clean oven");
+  await cleanupTestData(request, "tasks", "Clean fridge");
+  await cleanupTestData(request, "tasks", "Empty bins");
+  await cleanupTestData(request, "tasks", "Clean toilet");
+  await cleanupTestData(request, "tasks", "Clean shower/bath");
+  await cleanupTestData(request, "tasks", "Clean bathroom sink");
+  await cleanupTestData(request, "tasks", "Wash towels");
+  await cleanupTestData(request, "tasks", "Change bed sheets");
+  await cleanupTestData(request, "tasks", "Vacuum bedroom");
+  await cleanupTestData(request, "tasks", "Dust surfaces");
+  await cleanupTestData(request, "tasks", "Vacuum living room");
+  await cleanupTestData(request, "tasks", "Mop floors");
+  await cleanupTestData(request, "tasks", "Dust shelves");
+  await cleanupTestData(request, "tasks", "Mow lawn");
+  await cleanupTestData(request, "tasks", "Water garden");
+  await cleanupTestData(request, "tasks", "Sweep porch/patio");
+  await cleanupTestData(request, "tasks", "Do laundry");
+  await cleanupTestData(request, "tasks", "Iron clothes");
+  await cleanupTestData(request, "shopping", "Groceries");
+  await cleanupTestData(request, "recipes", "Pasta Bolognese");
+  await cleanupTestData(request, "recipes", "Chicken Stir-Fry");
+  await cleanupTestData(request, "recipes", "Scrambled Eggs on Toast");
+});
+
+test.describe.serial("Setup Wizard", () => {
+  test("GET /api/setup returns needsSetup status", async ({ request }) => {
+    const res = await request.get("/api/setup");
+    expect(res.ok()).toBeTruthy();
+    const data = await res.json();
+    expect(data).toHaveProperty("needsSetup");
+    expect(typeof data.needsSetup).toBe("boolean");
+  });
+
+  test("setup page loads and shows welcome step", async ({ page }) => {
+    await page.goto("/setup");
+    await page.waitForLoadState("networkidle");
+
+    // Should show the welcome screen (or redirect if setup not needed)
+    // Check for either the welcome heading or the dashboard
+    const welcomeHeading = page.getByRole("heading", {
+      name: "Welcome to Tuis",
+    });
+    const isSetupPage = await welcomeHeading.isVisible().catch(() => false);
+
+    if (isSetupPage) {
+      await expect(welcomeHeading).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Get Started" })
+      ).toBeVisible();
+    }
+    // If not visible, setup was already done — page redirected to dashboard
+  });
+
+  test("setup wizard navigates through all steps", async ({ page }) => {
+    await page.goto("/setup");
+    await page.waitForLoadState("networkidle");
+
+    const welcomeHeading = page.getByRole("heading", {
+      name: "Welcome to Tuis",
+    });
+    const isSetupPage = await welcomeHeading.isVisible().catch(() => false);
+
+    // Only run the full wizard flow if setup is actually needed
+    if (!isSetupPage) {
+      test.skip();
+      return;
+    }
+
+    // Step 0: Welcome → Click Get Started
+    await page.getByRole("button", { name: "Get Started" }).click();
+
+    // Step 1: Members → Should show "Who lives here?"
+    await expect(
+      page.getByRole("heading", { name: "Who lives here?" })
+    ).toBeVisible();
+
+    // Fill in a member name
+    await page.getByPlaceholder("Name").first().fill(TEST_USER_NAME);
+
+    // Verify color buttons have aria-labels
+    await expect(
+      page.getByRole("button", { name: "Select Blue" })
+    ).toBeVisible();
+
+    // Click Continue
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Step 2: Quick Start → Should show checkboxes
+    await expect(
+      page.getByRole("heading", { name: "Quick Start" })
+    ).toBeVisible();
+    await expect(page.getByText("Common household chores")).toBeVisible();
+    await expect(page.getByText("Sample shopping list")).toBeVisible();
+    await expect(page.getByText("Sample recipes")).toBeVisible();
+
+    // Click Back to verify navigation
+    await page.getByRole("button", { name: "Back" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Who lives here?" })
+    ).toBeVisible();
+
+    // Go forward again
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Quick Start" })
+    ).toBeVisible();
+
+    // Click Finish Setup
+    const responsePromise = page.waitForResponse(
+      (res) => res.url().includes("/api/users") && res.status() === 200
+    );
+    await page.getByRole("button", { name: "Finish Setup" }).click();
+    await responsePromise;
+
+    // Step 3: Done → Should show success
+    await expect(
+      page.getByRole("heading", { name: /all set/i })
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByRole("button", { name: "Go to Dashboard" })
+    ).toBeVisible();
+
+    // Click Go to Dashboard
+    await page.getByRole("button", { name: "Go to Dashboard" }).click();
+    await page.waitForLoadState("networkidle");
+
+    // Should be on the dashboard now
+    await expect(page).toHaveURL("/");
+  });
+
+  test("POST /api/setup returns 409 after setup is complete", async ({
+    request,
+  }) => {
+    // Setup is now complete (user was created in previous test)
+    const res = await request.post("/api/setup", {
+      data: { seedChores: true, seedShopping: true, seedRecipes: true },
+    });
+    // Should return 409 since users now exist
+    expect(res.status()).toBe(409);
+  });
+
+  test("visiting /setup after completion redirects away", async ({ page }) => {
+    await page.goto("/setup");
+    await page.waitForLoadState("networkidle");
+
+    // Should have been redirected to the dashboard
+    await expect(page).toHaveURL("/", { timeout: 5000 });
+  });
+});

--- a/src/app/api/__tests__/setup.test.ts
+++ b/src/app/api/__tests__/setup.test.ts
@@ -247,8 +247,10 @@ describe("Setup API", () => {
       expect(countRows("recipes")).toBe(3);
     });
 
-    it("returns 409 if users already exist (idempotency guard)", async () => {
-      insertUser("Existing User");
+    it("returns 409 if multiple users already exist (idempotency guard)", async () => {
+      // Simulate a household that already completed setup
+      insertUser("Alice");
+      insertUser("Bob");
 
       const req = makeRequest(
         "/api/setup",
@@ -264,6 +266,19 @@ describe("Setup API", () => {
       expect(countRows("tasks")).toBe(0);
       expect(countRows("shopping_lists")).toBe(0);
       expect(countRows("recipes")).toBe(0);
+    });
+
+    it("allows seeding when only one user exists (mid-setup)", async () => {
+      // During setup flow: one user just created, now seeding
+      insertUser("Alice");
+
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: true, seedShopping: false, seedRecipes: false })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(200);
+      expect(countRows("tasks")).toBe(21);
     });
 
     it("creates chores with correct areas and frequencies", async () => {

--- a/src/app/api/__tests__/setup.test.ts
+++ b/src/app/api/__tests__/setup.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+// ─── In-memory DB wiring ────────────────────────────────────────────────────
+
+let testDb: ReturnType<typeof drizzle>;
+let sqlite: Database.Database;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+  schema,
+}));
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL DEFAULT '#3b82f6',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      area TEXT NOT NULL,
+      frequency TEXT NOT NULL,
+      assigned_day TEXT,
+      season TEXT,
+      notes TEXT,
+      extended_notes TEXT,
+      assigned_to INTEGER REFERENCES users(id),
+      appliance_id INTEGER,
+      last_completed TEXT,
+      next_due TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS shopping_lists (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      color TEXT DEFAULT '#3b82f6',
+      sort_order INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS shopping_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      list_id INTEGER NOT NULL REFERENCES shopping_lists(id),
+      name TEXT NOT NULL,
+      quantity TEXT,
+      checked INTEGER DEFAULT 0,
+      sort_order INTEGER DEFAULT 0,
+      added_by INTEGER REFERENCES users(id),
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS recipes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      description TEXT,
+      instructions TEXT,
+      prep_time INTEGER,
+      cook_time INTEGER,
+      servings INTEGER,
+      image_url TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS recipe_ingredients (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      recipe_id INTEGER NOT NULL REFERENCES recipes(id),
+      name TEXT NOT NULL,
+      quantity TEXT,
+      amount REAL,
+      unit TEXT,
+      section TEXT,
+      sort_order INTEGER DEFAULT 0
+    );
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${url}`, init);
+}
+
+function jsonBody(data: Record<string, unknown>): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  };
+}
+
+function insertUser(name: string, color = "#3b82f6") {
+  return sqlite
+    .prepare("INSERT INTO users (name, color) VALUES (?, ?)")
+    .run(name, color);
+}
+
+function countRows(table: string): number {
+  return (sqlite.prepare(`SELECT COUNT(*) as count FROM ${table}`).get() as { count: number }).count;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SETUP API
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Setup API", () => {
+  let setupRoute: typeof import("@/app/api/setup/route");
+
+  beforeEach(async () => {
+    setupRoute = await import("@/app/api/setup/route");
+  });
+
+  // ── GET /api/setup ──────────────────────────────────────────────────
+
+  describe("GET /api/setup", () => {
+    it("returns needsSetup: true when no users exist", async () => {
+      const req = makeRequest("/api/setup");
+      const res = await setupRoute.GET();
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.needsSetup).toBe(true);
+    });
+
+    it("returns needsSetup: false when users exist", async () => {
+      insertUser("Test User");
+      const res = await setupRoute.GET();
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.needsSetup).toBe(false);
+    });
+  });
+
+  // ── POST /api/setup ─────────────────────────────────────────────────
+
+  describe("POST /api/setup", () => {
+    it("seeds chores when seedChores is true", async () => {
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: true, seedShopping: false, seedRecipes: false })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.results).toContain("Added 21 household chores");
+      expect(countRows("tasks")).toBe(21);
+    });
+
+    it("seeds shopping list when seedShopping is true", async () => {
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: false, seedShopping: true, seedRecipes: false })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(countRows("shopping_lists")).toBe(1);
+      expect(countRows("shopping_items")).toBe(15);
+
+      const list = sqlite
+        .prepare("SELECT name, color FROM shopping_lists")
+        .get() as { name: string; color: string };
+      expect(list.name).toBe("Groceries");
+      expect(list.color).toBe("#22c55e");
+    });
+
+    it("seeds recipes when seedRecipes is true", async () => {
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: false, seedShopping: false, seedRecipes: true })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(countRows("recipes")).toBe(3);
+
+      // Verify ingredients were created
+      const ingredientCount = countRows("recipe_ingredients");
+      expect(ingredientCount).toBeGreaterThan(0);
+
+      // Verify specific recipe
+      const bolognese = sqlite
+        .prepare("SELECT * FROM recipes WHERE name = ?")
+        .get("Pasta Bolognese") as { id: number; servings: number };
+      expect(bolognese).toBeTruthy();
+      expect(bolognese.servings).toBe(4);
+
+      // Verify its ingredients
+      const ingredients = sqlite
+        .prepare("SELECT * FROM recipe_ingredients WHERE recipe_id = ?")
+        .all(bolognese.id);
+      expect(ingredients).toHaveLength(8);
+    });
+
+    it("seeds nothing when all flags are false", async () => {
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: false, seedShopping: false, seedRecipes: false })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.results).toHaveLength(0);
+      expect(countRows("tasks")).toBe(0);
+      expect(countRows("shopping_lists")).toBe(0);
+      expect(countRows("recipes")).toBe(0);
+    });
+
+    it("seeds all data when all flags are true", async () => {
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: true, seedShopping: true, seedRecipes: true })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.results).toHaveLength(3);
+      expect(countRows("tasks")).toBe(21);
+      expect(countRows("shopping_lists")).toBe(1);
+      expect(countRows("shopping_items")).toBe(15);
+      expect(countRows("recipes")).toBe(3);
+    });
+
+    it("returns 409 if users already exist (idempotency guard)", async () => {
+      insertUser("Existing User");
+
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: true, seedShopping: true, seedRecipes: true })
+      );
+      const res = await setupRoute.POST(req);
+      expect(res.status).toBe(409);
+
+      const data = await res.json();
+      expect(data.error).toContain("already been completed");
+
+      // Verify nothing was seeded
+      expect(countRows("tasks")).toBe(0);
+      expect(countRows("shopping_lists")).toBe(0);
+      expect(countRows("recipes")).toBe(0);
+    });
+
+    it("creates chores with correct areas and frequencies", async () => {
+      const req = makeRequest(
+        "/api/setup",
+        jsonBody({ seedChores: true, seedShopping: false, seedRecipes: false })
+      );
+      await setupRoute.POST(req);
+
+      const kitchenTasks = sqlite
+        .prepare("SELECT * FROM tasks WHERE area = 'Kitchen'")
+        .all();
+      expect(kitchenTasks.length).toBe(6);
+
+      const dailyTasks = sqlite
+        .prepare("SELECT * FROM tasks WHERE frequency = 'daily'")
+        .all();
+      expect(dailyTasks.length).toBe(2);
+    });
+  });
+});

--- a/src/app/api/e2e-cleanup/route.ts
+++ b/src/app/api/e2e-cleanup/route.ts
@@ -12,6 +12,7 @@ import {
   recipes,
   recipeIngredients,
   mealPlan,
+  users,
 } from "@/lib/db/schema";
 import { like, eq, inArray, sql } from "drizzle-orm";
 
@@ -26,6 +27,7 @@ const VALID_TYPES = [
   "quotes",
   "recipes",
   "meals",
+  "users",
 ] as const;
 
 type CleanupType = (typeof VALID_TYPES)[number];
@@ -180,6 +182,14 @@ export async function POST(request: NextRequest) {
         const result = await db
           .delete(mealPlan)
           .where(like(mealPlan.customMeal, namePattern));
+        deleted = result.changes ?? 0;
+        break;
+      }
+
+      case "users": {
+        const result = await db
+          .delete(users)
+          .where(like(users.name, namePattern));
         deleted = result.changes ?? 0;
         break;
       }

--- a/src/app/api/e2e-cleanup/route.ts
+++ b/src/app/api/e2e-cleanup/route.ts
@@ -187,10 +187,31 @@ export async function POST(request: NextRequest) {
       }
 
       case "users": {
-        const result = await db
-          .delete(users)
+        // Find matching users
+        const matchingUsers = await db
+          .select({ id: users.id })
+          .from(users)
           .where(like(users.name, namePattern));
-        deleted = result.changes ?? 0;
+        if (matchingUsers.length > 0) {
+          const userIds = matchingUsers.map((u) => u.id);
+          // Nullify FK references in other tables
+          for (const uid of userIds) {
+            await db.run(
+              sql`UPDATE completions SET completed_by = NULL WHERE completed_by = ${uid}`
+            );
+            await db.run(
+              sql`UPDATE tasks SET assigned_to = NULL WHERE assigned_to = ${uid}`
+            );
+            await db.run(
+              sql`UPDATE shopping_items SET added_by = NULL WHERE added_by = ${uid}`
+            );
+          }
+          // Delete users
+          await db
+            .delete(users)
+            .where(inArray(users.id, userIds));
+          deleted = matchingUsers.length;
+        }
         break;
       }
     }

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -129,6 +129,15 @@ const STARTER_RECIPES = [
 
 export async function POST(request: Request) {
   try {
+    // Idempotency guard: don't seed if users already exist (setup already done)
+    const existingUsers = await db.select().from(users);
+    if (existingUsers.length > 0) {
+      return NextResponse.json(
+        { error: "Setup has already been completed" },
+        { status: 409 }
+      );
+    }
+
     const body = await request.json();
     const { seedChores, seedShopping, seedRecipes } = body;
     const results: string[] = [];

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -1,0 +1,207 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import {
+  users,
+  tasks,
+  shoppingLists,
+  shoppingItems,
+  recipes,
+  recipeIngredients,
+} from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const allUsers = await db.select().from(users);
+    return NextResponse.json({ needsSetup: allUsers.length === 0 });
+  } catch (error) {
+    console.error("Error checking setup status:", error);
+    return NextResponse.json(
+      { error: "Failed to check setup status" },
+      { status: 500 }
+    );
+  }
+}
+
+const STARTER_CHORES = [
+  // Kitchen
+  { name: "Wash dishes", area: "Kitchen", frequency: "daily" },
+  { name: "Wipe kitchen counters", area: "Kitchen", frequency: "daily" },
+  { name: "Clean stovetop", area: "Kitchen", frequency: "weekly" },
+  { name: "Clean oven", area: "Kitchen", frequency: "monthly" },
+  { name: "Clean fridge", area: "Kitchen", frequency: "monthly" },
+  { name: "Empty bins", area: "Kitchen", frequency: "twice-weekly" },
+  // Bathroom
+  { name: "Clean toilet", area: "Bathroom", frequency: "weekly" },
+  { name: "Clean shower/bath", area: "Bathroom", frequency: "weekly" },
+  { name: "Clean bathroom sink", area: "Bathroom", frequency: "weekly" },
+  { name: "Wash towels", area: "Bathroom", frequency: "weekly" },
+  // Bedroom
+  { name: "Change bed sheets", area: "Bedroom", frequency: "weekly" },
+  { name: "Vacuum bedroom", area: "Bedroom", frequency: "weekly" },
+  { name: "Dust surfaces", area: "Bedroom", frequency: "fortnightly" },
+  // Living areas
+  { name: "Vacuum living room", area: "Living Room", frequency: "weekly" },
+  { name: "Mop floors", area: "Living Room", frequency: "weekly" },
+  { name: "Dust shelves", area: "Living Room", frequency: "fortnightly" },
+  // Outdoor
+  { name: "Mow lawn", area: "Outdoor", frequency: "fortnightly" },
+  { name: "Water garden", area: "Outdoor", frequency: "twice-weekly" },
+  { name: "Sweep porch/patio", area: "Outdoor", frequency: "weekly" },
+  // Laundry
+  { name: "Do laundry", area: "Laundry", frequency: "twice-weekly" },
+  { name: "Iron clothes", area: "Laundry", frequency: "weekly" },
+];
+
+const STARTER_SHOPPING_ITEMS = [
+  "Milk",
+  "Bread",
+  "Eggs",
+  "Butter",
+  "Rice",
+  "Pasta",
+  "Onions",
+  "Garlic",
+  "Tomatoes",
+  "Chicken",
+  "Olive oil",
+  "Salt",
+  "Pepper",
+  "Cheese",
+  "Bananas",
+];
+
+const STARTER_RECIPES = [
+  {
+    name: "Pasta Bolognese",
+    description: "A classic hearty pasta with rich meat sauce",
+    prepTime: 15,
+    cookTime: 45,
+    servings: 4,
+    instructions:
+      "1. Brown mince in a large pan\n2. Add diced onion, garlic, and carrot, cook until soft\n3. Add tinned tomatoes, tomato paste, and herbs\n4. Simmer for 30 minutes\n5. Cook pasta according to packet directions\n6. Serve sauce over pasta with parmesan",
+    ingredients: [
+      { name: "Pasta", amount: 400, unit: "g" },
+      { name: "Beef mince", amount: 500, unit: "g" },
+      { name: "Onion", amount: 1, unit: "whole" },
+      { name: "Garlic cloves", amount: 3, unit: "whole" },
+      { name: "Tinned tomatoes", amount: 400, unit: "g" },
+      { name: "Tomato paste", amount: 2, unit: "tbsp" },
+      { name: "Carrot", amount: 1, unit: "whole" },
+      { name: "Parmesan", amount: 50, unit: "g" },
+    ],
+  },
+  {
+    name: "Chicken Stir-Fry",
+    description: "Quick and healthy weeknight stir-fry",
+    prepTime: 15,
+    cookTime: 10,
+    servings: 4,
+    instructions:
+      "1. Slice chicken into strips\n2. Cut vegetables into bite-sized pieces\n3. Heat oil in a wok over high heat\n4. Cook chicken until golden, set aside\n5. Stir-fry vegetables for 3-4 minutes\n6. Return chicken, add soy sauce and sesame oil\n7. Serve over rice",
+    ingredients: [
+      { name: "Chicken breast", amount: 500, unit: "g" },
+      { name: "Broccoli", amount: 1, unit: "whole" },
+      { name: "Capsicum", amount: 1, unit: "whole" },
+      { name: "Soy sauce", amount: 3, unit: "tbsp" },
+      { name: "Sesame oil", amount: 1, unit: "tsp" },
+      { name: "Rice", amount: 2, unit: "cup" },
+      { name: "Vegetable oil", amount: 2, unit: "tbsp" },
+    ],
+  },
+  {
+    name: "Scrambled Eggs on Toast",
+    description: "Simple and satisfying breakfast",
+    prepTime: 5,
+    cookTime: 5,
+    servings: 2,
+    instructions:
+      "1. Crack eggs into a bowl, add a splash of milk, season\n2. Whisk until combined\n3. Melt butter in a pan over medium-low heat\n4. Add eggs, stir gently with a spatula\n5. Remove from heat while still slightly wet\n6. Serve on buttered toast",
+    ingredients: [
+      { name: "Eggs", amount: 4, unit: "whole" },
+      { name: "Milk", amount: 2, unit: "tbsp" },
+      { name: "Butter", amount: 1, unit: "tbsp" },
+      { name: "Bread", amount: 4, unit: "slice" },
+    ],
+  },
+];
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { seedChores, seedShopping, seedRecipes } = body;
+    const results: string[] = [];
+
+    if (seedChores) {
+      for (const chore of STARTER_CHORES) {
+        await db.insert(tasks).values({
+          name: chore.name,
+          area: chore.area,
+          frequency: chore.frequency,
+          assignedDay: null,
+          season: null,
+          notes: null,
+          lastCompleted: null,
+          nextDue: null,
+          applianceId: null,
+        });
+      }
+      results.push(`Added ${STARTER_CHORES.length} household chores`);
+    }
+
+    if (seedShopping) {
+      const listResult = await db.insert(shoppingLists).values({
+        name: "Groceries",
+        color: "#22c55e",
+      });
+      const listId = Number(listResult.lastInsertRowid);
+
+      for (let i = 0; i < STARTER_SHOPPING_ITEMS.length; i++) {
+        await db.insert(shoppingItems).values({
+          listId,
+          name: STARTER_SHOPPING_ITEMS[i],
+          sortOrder: i,
+        });
+      }
+      results.push(
+        `Created shopping list with ${STARTER_SHOPPING_ITEMS.length} items`
+      );
+    }
+
+    if (seedRecipes) {
+      for (const recipe of STARTER_RECIPES) {
+        const recipeResult = await db.insert(recipes).values({
+          name: recipe.name,
+          description: recipe.description,
+          instructions: recipe.instructions,
+          prepTime: recipe.prepTime,
+          cookTime: recipe.cookTime,
+          servings: recipe.servings,
+        });
+        const recipeId = Number(recipeResult.lastInsertRowid);
+
+        for (let i = 0; i < recipe.ingredients.length; i++) {
+          const ing = recipe.ingredients[i];
+          await db.insert(recipeIngredients).values({
+            recipeId,
+            name: ing.name,
+            amount: ing.amount,
+            unit: ing.unit,
+            quantity: `${ing.amount} ${ing.unit}`,
+            sortOrder: i,
+          });
+        }
+      }
+      results.push(`Added ${STARTER_RECIPES.length} sample recipes`);
+    }
+
+    return NextResponse.json({ success: true, results });
+  } catch (error) {
+    console.error("Error seeding starter data:", error);
+    return NextResponse.json(
+      { error: "Failed to seed starter data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -130,8 +130,9 @@ const STARTER_RECIPES = [
 export async function POST(request: Request) {
   try {
     // Idempotency guard: don't seed if users already exist (setup already done)
+    // The /setup page also checks this on mount and redirects away
     const existingUsers = await db.select().from(users);
-    if (existingUsers.length > 0) {
+    if (existingUsers.length > 1) {
       return NextResponse.json(
         { error: "Setup has already been completed" },
         { status: 409 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,17 @@
+import { redirect } from "next/navigation";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
 import { Dashboard } from "@/components/dashboard";
 import { AppLayout } from "@/components/layout/AppLayout";
 
-export default function Home() {
+export const dynamic = "force-dynamic";
+
+export default async function Home() {
+  const allUsers = await db.select().from(users);
+  if (allUsers.length === 0) {
+    redirect("/setup");
+  }
+
   return (
     <AppLayout title="Dashboard">
       <Dashboard />

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -125,7 +125,7 @@ export default function SetupPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gray-50 dark:bg-zinc-950 flex items-center justify-center p-4">
       <div className="w-full max-w-lg">
         {/* Progress indicator */}
         <div className="flex items-center justify-center gap-2 mb-8">
@@ -137,7 +137,7 @@ export default function SetupPage() {
                   className={`flex items-center justify-center w-9 h-9 rounded-full transition-colors ${
                     i <= step
                       ? "bg-blue-600 text-white"
-                      : "bg-gray-200 text-gray-400"
+                      : "bg-gray-200 dark:bg-zinc-700 text-gray-400 dark:text-zinc-500"
                   }`}
                 >
                   <Icon className="h-4 w-4" />
@@ -145,7 +145,7 @@ export default function SetupPage() {
                 {i < STEPS.length - 1 && (
                   <div
                     className={`w-8 h-0.5 transition-colors ${
-                      i < step ? "bg-blue-600" : "bg-gray-200"
+                      i < step ? "bg-blue-600" : "bg-gray-200 dark:bg-zinc-700"
                     }`}
                   />
                 )}
@@ -159,15 +159,15 @@ export default function SetupPage() {
           <Card>
             <CardContent className="pt-8 pb-8 text-center space-y-6">
               <div className="flex justify-center">
-                <div className="w-16 h-16 rounded-2xl bg-blue-100 flex items-center justify-center">
+                <div className="w-16 h-16 rounded-2xl bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
                   <Home className="h-8 w-8 text-blue-600" />
                 </div>
               </div>
               <div className="space-y-2">
-                <h1 className="text-2xl font-bold text-gray-900">
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-zinc-100">
                   Welcome to Tuis
                 </h1>
-                <p className="text-gray-500 max-w-sm mx-auto">
+                <p className="text-gray-500 dark:text-zinc-400 max-w-sm mx-auto">
                   Your household companion for managing chores, meals, shopping,
                   and more. Let&apos;s get you set up in a few quick steps.
                 </p>
@@ -185,10 +185,10 @@ export default function SetupPage() {
           <Card>
             <CardContent className="pt-6 pb-6 space-y-6">
               <div className="text-center space-y-2">
-                <h2 className="text-xl font-bold text-gray-900">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
                   Who lives here?
                 </h2>
-                <p className="text-gray-500 text-sm">
+                <p className="text-gray-500 dark:text-zinc-400 text-sm">
                   Add the people in your household. You can always add more
                   later in Settings.
                 </p>
@@ -196,7 +196,7 @@ export default function SetupPage() {
 
               <div className="space-y-4">
                 {members.map((member, index) => (
-                  <div key={index} className="space-y-3 p-4 bg-gray-50 rounded-lg">
+                  <div key={index} className="space-y-3 p-4 bg-gray-50 dark:bg-zinc-800 rounded-lg">
                     <div className="flex items-center gap-2">
                       <div className="flex-1">
                         <Label htmlFor={`name-${index}`} className="sr-only">
@@ -216,7 +216,7 @@ export default function SetupPage() {
                         <Button
                           variant="ghost"
                           size="icon"
-                          className="text-red-500 hover:text-red-600 hover:bg-red-50 shrink-0"
+                          className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950 shrink-0"
                           onClick={() => removeMember(index)}
                         >
                           <Trash2 className="h-4 w-4" />
@@ -224,7 +224,7 @@ export default function SetupPage() {
                       )}
                     </div>
                     <div>
-                      <Label className="text-xs text-gray-500 mb-1.5 block">
+                      <Label className="text-xs text-gray-500 dark:text-zinc-400 mb-1.5 block">
                         Colour
                       </Label>
                       <div className="flex gap-2 flex-wrap">
@@ -234,7 +234,7 @@ export default function SetupPage() {
                             type="button"
                             className={`w-7 h-7 rounded-full transition-transform ${
                               member.color === color
-                                ? "ring-2 ring-offset-2 ring-gray-400 scale-110"
+                                ? "ring-2 ring-offset-2 ring-gray-400 dark:ring-zinc-500 dark:ring-offset-zinc-800 scale-110"
                                 : ""
                             }`}
                             style={{ backgroundColor: color }}
@@ -289,17 +289,17 @@ export default function SetupPage() {
           <Card>
             <CardContent className="pt-6 pb-6 space-y-6">
               <div className="text-center space-y-2">
-                <h2 className="text-xl font-bold text-gray-900">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
                   Quick Start
                 </h2>
-                <p className="text-gray-500 text-sm">
+                <p className="text-gray-500 dark:text-zinc-400 text-sm">
                   Want some starter data to get going? You can skip this and
                   add everything yourself.
                 </p>
               </div>
 
               <div className="space-y-3">
-                <label className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors">
+                <label className="flex items-start gap-3 p-4 bg-gray-50 dark:bg-zinc-800 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors">
                   <Checkbox
                     checked={seedChores}
                     onCheckedChange={(checked) =>
@@ -308,17 +308,17 @@ export default function SetupPage() {
                     className="mt-0.5"
                   />
                   <div>
-                    <div className="font-medium text-gray-900">
+                    <div className="font-medium text-gray-900 dark:text-zinc-100">
                       Common household chores
                     </div>
-                    <div className="text-sm text-gray-500">
+                    <div className="text-sm text-gray-500 dark:text-zinc-400">
                       Kitchen, bathroom, bedroom, living room, outdoor, and
                       laundry tasks with suggested frequencies
                     </div>
                   </div>
                 </label>
 
-                <label className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors">
+                <label className="flex items-start gap-3 p-4 bg-gray-50 dark:bg-zinc-800 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors">
                   <Checkbox
                     checked={seedShopping}
                     onCheckedChange={(checked) =>
@@ -327,16 +327,16 @@ export default function SetupPage() {
                     className="mt-0.5"
                   />
                   <div>
-                    <div className="font-medium text-gray-900">
+                    <div className="font-medium text-gray-900 dark:text-zinc-100">
                       Sample shopping list
                     </div>
-                    <div className="text-sm text-gray-500">
+                    <div className="text-sm text-gray-500 dark:text-zinc-400">
                       A &quot;Groceries&quot; list with common pantry staples
                     </div>
                   </div>
                 </label>
 
-                <label className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors">
+                <label className="flex items-start gap-3 p-4 bg-gray-50 dark:bg-zinc-800 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors">
                   <Checkbox
                     checked={seedRecipes}
                     onCheckedChange={(checked) =>
@@ -345,10 +345,10 @@ export default function SetupPage() {
                     className="mt-0.5"
                   />
                   <div>
-                    <div className="font-medium text-gray-900">
+                    <div className="font-medium text-gray-900 dark:text-zinc-100">
                       Sample recipes
                     </div>
-                    <div className="text-sm text-gray-500">
+                    <div className="text-sm text-gray-500 dark:text-zinc-400">
                       A few simple recipes to get your meal planning started
                     </div>
                   </div>
@@ -396,15 +396,15 @@ export default function SetupPage() {
           <Card>
             <CardContent className="pt-8 pb-8 text-center space-y-6">
               <div className="flex justify-center">
-                <div className="w-16 h-16 rounded-2xl bg-green-100 flex items-center justify-center">
+                <div className="w-16 h-16 rounded-2xl bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
                   <PartyPopper className="h-8 w-8 text-green-600" />
                 </div>
               </div>
               <div className="space-y-2">
-                <h1 className="text-2xl font-bold text-gray-900">
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-zinc-100">
                   You&apos;re all set!
                 </h1>
-                <p className="text-gray-500 max-w-sm mx-auto">
+                <p className="text-gray-500 dark:text-zinc-400 max-w-sm mx-auto">
                   Your household is ready to go. Head to the dashboard to start
                   managing your home.
                 </p>

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -19,15 +19,15 @@ import {
   Loader2,
 } from "lucide-react";
 
-const COLORS = [
-  "#3b82f6", // blue
-  "#ef4444", // red
-  "#22c55e", // green
-  "#f59e0b", // amber
-  "#8b5cf6", // violet
-  "#ec4899", // pink
-  "#06b6d4", // cyan
-  "#f97316", // orange
+const COLORS: Array<{ hex: string; label: string }> = [
+  { hex: "#3b82f6", label: "Blue" },
+  { hex: "#ef4444", label: "Red" },
+  { hex: "#22c55e", label: "Green" },
+  { hex: "#f59e0b", label: "Amber" },
+  { hex: "#8b5cf6", label: "Violet" },
+  { hex: "#ec4899", label: "Pink" },
+  { hex: "#06b6d4", label: "Cyan" },
+  { hex: "#f97316", label: "Orange" },
 ];
 
 interface Member {
@@ -46,18 +46,33 @@ export default function SetupPage() {
   const router = useRouter();
   const [step, setStep] = useState(0);
   const [members, setMembers] = useState<Member[]>([
-    { name: "", color: COLORS[0] },
+    { name: "", color: COLORS[0].hex },
   ]);
   const [seedChores, setSeedChores] = useState(true);
   const [seedShopping, setSeedShopping] = useState(true);
   const [seedRecipes, setSeedRecipes] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isCheckingSetup, setIsCheckingSetup] = useState(true);
+
+  // Redirect away if setup is already complete
+  useEffect(() => {
+    fetch("/api/setup")
+      .then((res) => res.json())
+      .then((data) => {
+        if (!data.needsSetup) {
+          router.replace("/");
+        } else {
+          setIsCheckingSetup(false);
+        }
+      })
+      .catch(() => setIsCheckingSetup(false));
+  }, [router]);
 
   const addMember = () => {
     setMembers([
       ...members,
-      { name: "", color: COLORS[members.length % COLORS.length] },
+      { name: "", color: COLORS[members.length % COLORS.length].hex },
     ]);
   };
 
@@ -123,6 +138,14 @@ export default function SetupPage() {
     router.push("/");
     router.refresh();
   };
+
+  if (isCheckingSetup) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-zinc-950 flex items-center justify-center p-4">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-zinc-950 flex items-center justify-center p-4">
@@ -228,18 +251,19 @@ export default function SetupPage() {
                         Colour
                       </Label>
                       <div className="flex gap-2 flex-wrap">
-                        {COLORS.map((color) => (
+                        {COLORS.map(({ hex, label }) => (
                           <button
-                            key={color}
+                            key={hex}
                             type="button"
+                            aria-label={`Select ${label}`}
                             className={`w-7 h-7 rounded-full transition-transform ${
-                              member.color === color
+                              member.color === hex
                                 ? "ring-2 ring-offset-2 ring-gray-400 dark:ring-zinc-500 dark:ring-offset-zinc-800 scale-110"
                                 : ""
                             }`}
-                            style={{ backgroundColor: color }}
+                            style={{ backgroundColor: hex }}
                             onClick={() =>
-                              updateMember(index, "color", color)
+                              updateMember(index, "color", hex)
                             }
                           />
                         ))}
@@ -272,7 +296,7 @@ export default function SetupPage() {
                   Back
                 </Button>
                 <Button
-                  onClick={() => setStep(2)}
+                  onClick={() => { setError(null); setStep(2); }}
                   disabled={!canProceedFromMembers}
                   className="flex-1 gap-2"
                 >

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Home,
+  Users,
+  Sparkles,
+  PartyPopper,
+  Plus,
+  Trash2,
+  ArrowRight,
+  ArrowLeft,
+  Loader2,
+} from "lucide-react";
+
+const COLORS = [
+  "#3b82f6", // blue
+  "#ef4444", // red
+  "#22c55e", // green
+  "#f59e0b", // amber
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#06b6d4", // cyan
+  "#f97316", // orange
+];
+
+interface Member {
+  name: string;
+  color: string;
+}
+
+const STEPS = [
+  { label: "Welcome", icon: Home },
+  { label: "Members", icon: Users },
+  { label: "Quick Start", icon: Sparkles },
+  { label: "Done", icon: PartyPopper },
+];
+
+export default function SetupPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [members, setMembers] = useState<Member[]>([
+    { name: "", color: COLORS[0] },
+  ]);
+  const [seedChores, setSeedChores] = useState(true);
+  const [seedShopping, setSeedShopping] = useState(true);
+  const [seedRecipes, setSeedRecipes] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addMember = () => {
+    setMembers([
+      ...members,
+      { name: "", color: COLORS[members.length % COLORS.length] },
+    ]);
+  };
+
+  const removeMember = (index: number) => {
+    if (members.length <= 1) return;
+    setMembers(members.filter((_, i) => i !== index));
+  };
+
+  const updateMember = (
+    index: number,
+    field: keyof Member,
+    value: string
+  ) => {
+    const updated = [...members];
+    updated[index] = { ...updated[index], [field]: value };
+    setMembers(updated);
+  };
+
+  const validMembers = members.filter((m) => m.name.trim().length > 0);
+
+  const canProceedFromMembers = validMembers.length >= 1;
+
+  const handleFinish = async () => {
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      // Create all members
+      for (const member of validMembers) {
+        const res = await fetch("/api/users", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: member.name.trim(), color: member.color }),
+        });
+        if (!res.ok) {
+          throw new Error(`Failed to create member: ${member.name}`);
+        }
+      }
+
+      // Seed starter data if any selected
+      if (seedChores || seedShopping || seedRecipes) {
+        const res = await fetch("/api/setup", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ seedChores, seedShopping, seedRecipes }),
+        });
+        if (!res.ok) {
+          throw new Error("Failed to seed starter data");
+        }
+      }
+
+      setStep(3);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Something went wrong"
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const goToDashboard = () => {
+    router.push("/");
+    router.refresh();
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+      <div className="w-full max-w-lg">
+        {/* Progress indicator */}
+        <div className="flex items-center justify-center gap-2 mb-8">
+          {STEPS.map((s, i) => {
+            const Icon = s.icon;
+            return (
+              <div key={s.label} className="flex items-center gap-2">
+                <div
+                  className={`flex items-center justify-center w-9 h-9 rounded-full transition-colors ${
+                    i <= step
+                      ? "bg-blue-600 text-white"
+                      : "bg-gray-200 text-gray-400"
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                </div>
+                {i < STEPS.length - 1 && (
+                  <div
+                    className={`w-8 h-0.5 transition-colors ${
+                      i < step ? "bg-blue-600" : "bg-gray-200"
+                    }`}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Step 0: Welcome */}
+        {step === 0 && (
+          <Card>
+            <CardContent className="pt-8 pb-8 text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-16 h-16 rounded-2xl bg-blue-100 flex items-center justify-center">
+                  <Home className="h-8 w-8 text-blue-600" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h1 className="text-2xl font-bold text-gray-900">
+                  Welcome to Tuis
+                </h1>
+                <p className="text-gray-500 max-w-sm mx-auto">
+                  Your household companion for managing chores, meals, shopping,
+                  and more. Let&apos;s get you set up in a few quick steps.
+                </p>
+              </div>
+              <Button onClick={() => setStep(1)} size="lg" className="gap-2">
+                Get Started
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 1: Household Members */}
+        {step === 1 && (
+          <Card>
+            <CardContent className="pt-6 pb-6 space-y-6">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-bold text-gray-900">
+                  Who lives here?
+                </h2>
+                <p className="text-gray-500 text-sm">
+                  Add the people in your household. You can always add more
+                  later in Settings.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                {members.map((member, index) => (
+                  <div key={index} className="space-y-3 p-4 bg-gray-50 rounded-lg">
+                    <div className="flex items-center gap-2">
+                      <div className="flex-1">
+                        <Label htmlFor={`name-${index}`} className="sr-only">
+                          Name
+                        </Label>
+                        <Input
+                          id={`name-${index}`}
+                          value={member.name}
+                          onChange={(e) =>
+                            updateMember(index, "name", e.target.value)
+                          }
+                          placeholder="Name"
+                          autoFocus={index === 0}
+                        />
+                      </div>
+                      {members.length > 1 && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-red-500 hover:text-red-600 hover:bg-red-50 shrink-0"
+                          onClick={() => removeMember(index)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                    <div>
+                      <Label className="text-xs text-gray-500 mb-1.5 block">
+                        Colour
+                      </Label>
+                      <div className="flex gap-2 flex-wrap">
+                        {COLORS.map((color) => (
+                          <button
+                            key={color}
+                            type="button"
+                            className={`w-7 h-7 rounded-full transition-transform ${
+                              member.color === color
+                                ? "ring-2 ring-offset-2 ring-gray-400 scale-110"
+                                : ""
+                            }`}
+                            style={{ backgroundColor: color }}
+                            onClick={() =>
+                              updateMember(index, "color", color)
+                            }
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <Button
+                variant="outline"
+                onClick={addMember}
+                className="w-full gap-2"
+              >
+                <Plus className="h-4 w-4" />
+                Add Another Person
+              </Button>
+
+              {error && (
+                <p className="text-sm text-red-600 text-center">{error}</p>
+              )}
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={() => setStep(0)}
+                  className="gap-2"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </Button>
+                <Button
+                  onClick={() => setStep(2)}
+                  disabled={!canProceedFromMembers}
+                  className="flex-1 gap-2"
+                >
+                  Continue
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 2: Quick Start */}
+        {step === 2 && (
+          <Card>
+            <CardContent className="pt-6 pb-6 space-y-6">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-bold text-gray-900">
+                  Quick Start
+                </h2>
+                <p className="text-gray-500 text-sm">
+                  Want some starter data to get going? You can skip this and
+                  add everything yourself.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <label className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors">
+                  <Checkbox
+                    checked={seedChores}
+                    onCheckedChange={(checked) =>
+                      setSeedChores(checked === true)
+                    }
+                    className="mt-0.5"
+                  />
+                  <div>
+                    <div className="font-medium text-gray-900">
+                      Common household chores
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      Kitchen, bathroom, bedroom, living room, outdoor, and
+                      laundry tasks with suggested frequencies
+                    </div>
+                  </div>
+                </label>
+
+                <label className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors">
+                  <Checkbox
+                    checked={seedShopping}
+                    onCheckedChange={(checked) =>
+                      setSeedShopping(checked === true)
+                    }
+                    className="mt-0.5"
+                  />
+                  <div>
+                    <div className="font-medium text-gray-900">
+                      Sample shopping list
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      A &quot;Groceries&quot; list with common pantry staples
+                    </div>
+                  </div>
+                </label>
+
+                <label className="flex items-start gap-3 p-4 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors">
+                  <Checkbox
+                    checked={seedRecipes}
+                    onCheckedChange={(checked) =>
+                      setSeedRecipes(checked === true)
+                    }
+                    className="mt-0.5"
+                  />
+                  <div>
+                    <div className="font-medium text-gray-900">
+                      Sample recipes
+                    </div>
+                    <div className="text-sm text-gray-500">
+                      A few simple recipes to get your meal planning started
+                    </div>
+                  </div>
+                </label>
+              </div>
+
+              {error && (
+                <p className="text-sm text-red-600 text-center">{error}</p>
+              )}
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={() => setStep(1)}
+                  className="gap-2"
+                  disabled={isSaving}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </Button>
+                <Button
+                  onClick={handleFinish}
+                  disabled={isSaving}
+                  className="flex-1 gap-2"
+                >
+                  {isSaving ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Setting up...
+                    </>
+                  ) : (
+                    <>
+                      Finish Setup
+                      <ArrowRight className="h-4 w-4" />
+                    </>
+                  )}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 3: Done */}
+        {step === 3 && (
+          <Card>
+            <CardContent className="pt-8 pb-8 text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-16 h-16 rounded-2xl bg-green-100 flex items-center justify-center">
+                  <PartyPopper className="h-8 w-8 text-green-600" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h1 className="text-2xl font-bold text-gray-900">
+                  You&apos;re all set!
+                </h1>
+                <p className="text-gray-500 max-w-sm mx-auto">
+                  Your household is ready to go. Head to the dashboard to start
+                  managing your home.
+                </p>
+              </div>
+              <Button onClick={goToDashboard} size="lg" className="gap-2">
+                Go to Dashboard
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Detects first-time setup (no users in DB) and redirects to `/setup`
- 4-step wizard: Welcome, Household Members, Quick Start, Done
- Quick Start seeds common chores (21 tasks), shopping list (15 items), sample recipes (3)
- CLAUDE.md with project documentation

## Test plan
- [ ] Fresh DB redirects to /setup
- [ ] Can add multiple household members with colours
- [ ] Quick start seeds create data visible on dashboard
- [ ] After setup, normal app loads without redirect
