### PR TITLE
Add CI, setup wizard tests, dark mode & idempotency fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      # TODO: fix 6 pre-existing lint errors then remove continue-on-error
       - run: npm run lint
-        continue-on-error: true
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # TODO: fix 6 pre-existing lint errors then remove continue-on-error
       - run: npm run lint
+        continue-on-error: true
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,26 @@
+import { request } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:3000";
+
+/**
+ * Ensures at least one user exists before e2e tests run.
+ * In CI the database starts empty, so without this the app redirects to /setup.
+ */
+async function globalSetup() {
+  const ctx = await request.newContext({ baseURL: BASE_URL });
+
+  // Check if setup is needed
+  const res = await ctx.get("/api/setup");
+  const { needsSetup } = await res.json();
+
+  if (needsSetup) {
+    // Create a default test user so the app works normally
+    await ctx.post("/api/users", {
+      data: { name: "E2E Test User", color: "#3b82f6" },
+    });
+  }
+
+  await ctx.dispose();
+}
+
+export default globalSetup;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,13 +7,22 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
+  globalSetup: "./e2e/global-setup.ts",
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
   },
   projects: [
     {
+      // Setup spec deletes all users — must run alone before other tests
+      name: "setup",
+      testMatch: "setup.spec.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       name: "chromium",
+      testIgnore: "setup.spec.ts",
+      dependencies: ["setup"],
       use: { ...devices["Desktop Chrome"] },
     },
   ],

--- a/src/app/api/__tests__/quotes.test.ts
+++ b/src/app/api/__tests__/quotes.test.ts
@@ -609,14 +609,18 @@ describe("Recent Completions API", () => {
         startOfWeek(new Date(), { weekStartsOn: 1 }),
         "yyyy-MM-dd"
       );
-      const today = format(new Date(), "yyyy-MM-dd");
+      // Ensure a later date even if today is Monday (when weekStart === today)
+      const laterDate = format(
+        new Date(startOfWeek(new Date(), { weekStartsOn: 1 }).getTime() + 86400000),
+        "yyyy-MM-dd"
+      );
 
       const task1 = insertTask("Task A", "Kitchen", "Daily");
       const task2 = insertTask("Task B", "Bathroom", "Daily");
 
       // Insert in ascending order
       insertCompletion(Number(task1.lastInsertRowid), weekStart);
-      insertCompletion(Number(task2.lastInsertRowid), today);
+      insertCompletion(Number(task2.lastInsertRowid), laterDate);
 
       const res = await recentRoute.GET();
       const data = await res.json();

--- a/src/app/api/appliances/route.ts
+++ b/src/app/api/appliances/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: Request) {
     const search = searchParams.get("search");
     const location = searchParams.get("location");
 
-    let query = db.select().from(appliances);
+    const query = db.select().from(appliances);
 
     const conditions = [];
 

--- a/src/app/api/quotes/budget/route.ts
+++ b/src/app/api/quotes/budget/route.ts
@@ -8,6 +8,7 @@ export async function GET() {
   try {
     const response = await fetch(`${ACTUAL_API_URL}/api/budget/summary`, {
       next: { revalidate: 300 }, // Cache for 5 minutes
+      signal: AbortSignal.timeout(5000),
     });
 
     if (!response.ok) {

--- a/src/app/api/together/route.ts
+++ b/src/app/api/together/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
     const category = searchParams.get("category");
     const query = searchParams.get("q");
 
-    let conditions = [];
+    const conditions = [];
 
     if (status) {
       conditions.push(eq(activities.status, status));

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ const themeScript = `
   try {
     var t = localStorage.getItem('tuis-theme');
     var d = (t === 'dark') || (t !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
-    if (d) document.documentElement.classList.add('dark'); else document.documentElement.classList.remove('dark'); else document.documentElement.classList.remove('dark');
+    if (d) document.documentElement.classList.add('dark'); else document.documentElement.classList.remove('dark');
   } catch(e) {}
 })();
 `;

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -33,22 +33,21 @@ function applyTheme(theme: Theme) {
   return resolved;
 }
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>("system");
-  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("light");
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  try {
+    return (localStorage.getItem(STORAGE_KEY) as Theme) || "system";
+  } catch {
+    return "system";
+  }
+}
 
-  // Initialize from localStorage on mount
-  useEffect(() => {
-    let stored: Theme | null = null;
-    try {
-      stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
-    } catch (e) {
-      // localStorage may be unavailable (SSR, private browsing, etc.)
-    }
-    const initial = stored || "system";
-    setThemeState(initial);
-    setResolvedTheme(applyTheme(initial));
-  }, []);
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getStoredTheme);
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() => {
+    if (typeof window === "undefined") return "light";
+    return applyTheme(getStoredTheme());
+  });
 
   // Listen for system theme changes
   useEffect(() => {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -85,7 +85,7 @@ export function AppLayout({ children, title, actions }: AppLayoutProps) {
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
 
-  const NavContent = () => (
+  const navContent = (
     <nav className="flex-1 overflow-y-auto py-4">
       {navigation.map((group) => (
         <div key={group.title} className="mb-4">
@@ -167,7 +167,7 @@ export function AppLayout({ children, title, actions }: AppLayoutProps) {
             <X className="h-5 w-5" />
           </Button>
         </div>
-        <NavContent />
+        {navContent}
         <div className="p-3 border-t border-sidebar-border">
           <ThemeToggle />
         </div>
@@ -197,7 +197,7 @@ export function AppLayout({ children, title, actions }: AppLayoutProps) {
             )}
           </Button>
         </div>
-        <NavContent />
+        {navContent}
         <div className={cn("p-3 border-t border-sidebar-border", isCollapsed ? "px-1" : "")}>
           <ThemeToggle collapsed={isCollapsed} />
         </div>

--- a/src/components/vehicles/VehicleDetail.tsx
+++ b/src/components/vehicles/VehicleDetail.tsx
@@ -428,12 +428,13 @@ export function VehicleDetail({
     }
   }, [vehicle, activeTab]);
 
-  useEffect(() => {
-    if (open) {
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
       setActiveTab("overview");
       setCostSummary(null);
     }
-  }, [open]);
+    onOpenChange(isOpen);
+  };
 
   if (!vehicle) return null;
 
@@ -449,7 +450,7 @@ export function VehicleDetail({
   ];
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-start justify-between">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    exclude: ["e2e/**", "node_modules/**"],
+  },
 });


### PR DESCRIPTION
## Summary
- Add CI workflow (lint, unit tests, Playwright e2e) that runs on all PRs to master
- Add dark mode support to setup wizard (missing from PR #18)
- Add idempotency guard and re-entry protection to setup flow
- Add comprehensive tests: 10 unit tests for setup API, 5 e2e tests for wizard flow
- Add vitest.config.ts with path alias resolution (fixes existing test imports)
- Add `users` cleanup type to e2e-cleanup endpoint with FK-safe deletion
- Add accessibility: aria-labels on color picker buttons
- Update CLAUDE.md with testing patterns and dark mode docs

## Test plan
- [x] `npm test` — 10/10 setup unit tests pass
- [x] `npm run test:e2e -- e2e/setup.spec.ts` — 5/5 e2e tests pass
- [x] `npm run build` — builds cleanly
- [x] Setup wizard flow works end-to-end (backed by e2e tests)
- [x] Re-visiting /setup after completion redirects to dashboard
- [x] Dark mode renders correctly on setup page

🤖 Generated with [Claude Code](https://claude.com/claude-code)