### PR TITLE
Add meal slots: side, main, and dessert per day

### DIFF
--- a/e2e/meals.spec.ts
+++ b/e2e/meals.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect, Page } from "@playwright/test";
 import { cleanupTestData } from "./cleanup";
 
-const TEST_RECIPE_NAME = `E2E Test Recipe ${Date.now()}`;
+const TEST_RECIPE_NAME = `E2E Meal Slot Recipe ${Date.now()}`;
+const TEST_SIDE_NAME = `E2E Side Recipe ${Date.now()}`;
+const TEST_CUSTOM_DESSERT = `E2E Custom Dessert ${Date.now()}`;
 
 async function dismissUserPickerIfVisible(page: Page) {
   await page.waitForLoadState("networkidle");
@@ -21,12 +23,13 @@ async function dismissUserPickerIfVisible(page: Page) {
 }
 
 test.afterAll(async ({ request }) => {
-  // Clean up recipe (also removes associated ingredients and meal plan entries)
-  await cleanupTestData(request, "recipes", "E2E Test Recipe%");
+  await cleanupTestData(request, "recipes", "E2E Meal Slot Recipe%");
+  await cleanupTestData(request, "recipes", "E2E Side Recipe%");
+  await cleanupTestData(request, "meals", "E2E Custom Dessert%");
 });
 
 test.describe("Meal Planning", () => {
-  test("should navigate to meals page and see week view", async ({ page }) => {
+  test("should navigate to meals page and see week view with slot labels", async ({ page }) => {
     await page.goto("/meals");
     await dismissUserPickerIfVisible(page);
 
@@ -34,12 +37,11 @@ test.describe("Meal Planning", () => {
       page.getByRole("heading", { name: "Meal Planner" }).first()
     ).toBeVisible();
 
-    // Wait for loading to finish
     await expect(page.getByText("Loading meals...")).not.toBeVisible({
       timeout: 10000,
     });
 
-    // Should show day names in the week grid (at least one day should be visible)
+    // Should show day names
     const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
     let foundDays = 0;
     for (const day of dayNames) {
@@ -49,6 +51,11 @@ test.describe("Meal Planning", () => {
       }
     }
     expect(foundDays).toBeGreaterThan(0);
+
+    // Should show slot labels (Side, Main, Dessert) in the grid
+    await expect(page.getByText("Side").first()).toBeVisible();
+    await expect(page.getByText("Main").first()).toBeVisible();
+    await expect(page.getByText("Dessert").first()).toBeVisible();
   });
 
   test("should navigate weeks with prev/next buttons", async ({ page }) => {
@@ -58,28 +65,22 @@ test.describe("Meal Planning", () => {
       timeout: 10000,
     });
 
-    // Get the current week label
     const weekLabel = page.locator("span.font-medium.text-lg");
     const initialText = await weekLabel.textContent();
 
-    // Click next week
     const nextBtn = page.locator("button").filter({ has: page.locator("svg.lucide-chevron-right") }).first();
     await nextBtn.click();
     await page.waitForLoadState("networkidle");
 
-    // Week label should have changed
     const newText = await weekLabel.textContent();
     expect(newText).not.toBe(initialText);
 
-    // "Today" button should appear when not on current week
     const todayBtn = page.getByRole("button", { name: "Today" });
     await expect(todayBtn).toBeVisible();
 
-    // Click Today to go back
     await todayBtn.click();
     await page.waitForLoadState("networkidle");
 
-    // Should be back to original week
     const restoredText = await weekLabel.textContent();
     expect(restoredText).toBe(initialText);
   });
@@ -92,56 +93,41 @@ test.describe("Meal Planning", () => {
       page.getByRole("heading", { name: "Recipe Library" }).first()
     ).toBeVisible();
 
-    // Wait for loading
     await expect(page.getByText("Loading recipes...")).not.toBeVisible({
       timeout: 10000,
     });
   });
 
-  test("should create a new recipe with ingredients", async ({ page }) => {
+  test("should create a main recipe with category", async ({ page }) => {
     await page.goto("/recipes");
     await dismissUserPickerIfVisible(page);
     await expect(page.getByText("Loading recipes...")).not.toBeVisible({
       timeout: 10000,
     });
 
-    // Click "New Recipe" button
     await page.getByRole("button", { name: "New Recipe" }).click();
 
-    // Wait for dialog
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
-    await expect(
-      dialog.getByRole("heading", { name: "New Recipe" })
-    ).toBeVisible();
 
-    // Fill in recipe details
     await dialog.getByLabel("Recipe Name").fill(TEST_RECIPE_NAME);
-    await dialog.getByLabel("Description").fill("A delicious test recipe");
+    await dialog.getByLabel("Description").fill("A main course test recipe");
     await dialog.getByLabel("Prep Time (min)").fill("15");
     await dialog.getByLabel("Cook Time (min)").fill("30");
     await dialog.getByLabel("Servings").fill("4");
 
-    // Fill in the first ingredient (there's already one empty row)
-    const ingredientNameInputs = dialog.locator(
-      "input[placeholder='Ingredient name']"
-    );
-    await ingredientNameInputs.first().fill("Pasta");
+    // Category should default to Main — verify the selector exists
+    const categoryTrigger = dialog.locator("button[role='combobox']").filter({ hasText: "Main" });
+    await expect(categoryTrigger).toBeVisible();
 
+    // Fill ingredient
+    const ingredientNameInputs = dialog.locator("input[placeholder='Ingredient name']");
+    await ingredientNameInputs.first().fill("Pasta");
     const amountInputs = dialog.locator("input[placeholder='Amt']");
     await amountInputs.first().fill("500");
 
-    // Add another ingredient
-    await dialog.getByRole("button", { name: "Add Ingredient" }).click();
-    await ingredientNameInputs.nth(1).fill("Tomato Sauce");
-    await amountInputs.nth(1).fill("400");
+    await dialog.getByLabel("Instructions").fill("1. Cook\n2. Serve");
 
-    // Fill instructions
-    await dialog
-      .getByLabel("Instructions")
-      .fill("1. Boil pasta\n2. Heat sauce\n3. Combine and serve");
-
-    // Submit
     const responsePromise = page.waitForResponse(
       (resp) =>
         resp.url().includes("/api/recipes") &&
@@ -150,13 +136,240 @@ test.describe("Meal Planning", () => {
     await dialog.getByRole("button", { name: "Create Recipe" }).click();
     await responsePromise;
 
-    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(TEST_RECIPE_NAME)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should create a side recipe with side category", async ({ page }) => {
+    await page.goto("/recipes");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByRole("button", { name: "New Recipe" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel("Recipe Name").fill(TEST_SIDE_NAME);
+    await dialog.getByLabel("Description").fill("A side dish");
+    await dialog.getByLabel("Prep Time (min)").fill("5");
+    await dialog.getByLabel("Cook Time (min)").fill("10");
+    await dialog.getByLabel("Servings").fill("4");
+
+    // Change category to Side
+    const categoryTrigger = dialog.locator("button[role='combobox']").filter({ hasText: "Main" });
+    await categoryTrigger.click();
+    await page.getByRole("option", { name: "Side" }).click();
+
+    const ingredientNameInputs = dialog.locator("input[placeholder='Ingredient name']");
+    await ingredientNameInputs.first().fill("Bread");
+    const amountInputs = dialog.locator("input[placeholder='Amt']");
+    await amountInputs.first().fill("1");
+
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/recipes") &&
+        resp.request().method() === "POST"
+    );
+    await dialog.getByRole("button", { name: "Create Recipe" }).click();
+    await responsePromise;
+
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(TEST_SIDE_NAME)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should add a recipe to the main slot", async ({ page }) => {
+    await page.goto("/meals");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading meals...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Navigate ahead to get empty slots
+    const nextBtn = page.locator("button").filter({ has: page.locator("svg.lucide-chevron-right") }).first();
+    for (let i = 0; i < 5; i++) {
+      await nextBtn.click();
+      await page.waitForLoadState("networkidle");
+    }
+
+    // Click the "Add" button in a Main slot
+    // The slot label "Main" is followed by an "Add" button
+    const mainAddBtns = page.locator("div").filter({ hasText: /^Main$/ }).locator(".. >> button:has-text('Add')");
+    const addBtn = mainAddBtns.first();
+    await expect(addBtn).toBeVisible({ timeout: 5000 });
+    await addBtn.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Dialog title should mention "Main"
+    await expect(dialog.getByText("Add Main for")).toBeVisible();
+
+    // Find and click our test recipe
+    const recipeOption = dialog.getByText(TEST_RECIPE_NAME);
+    await expect(recipeOption).toBeVisible({ timeout: 5000 });
+    await recipeOption.click();
+
+    // Confirm at 1x
+    const addToPlanBtn = dialog.getByRole("button", { name: "Add to Plan" });
+    await expect(addToPlanBtn).toBeVisible({ timeout: 5000 });
+
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/meals/") &&
+        resp.request().method() === "PUT"
+    );
+    await addToPlanBtn.click();
+    await responsePromise;
+
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
 
-    // Recipe should appear in the list
-    await expect(page.getByText(TEST_RECIPE_NAME)).toBeVisible({
-      timeout: 5000,
+    // Recipe name should appear in the grid
+    await expect(page.getByText(TEST_RECIPE_NAME).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should add a recipe to the side slot on the same day", async ({ page }) => {
+    await page.goto("/meals");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading meals...")).not.toBeVisible({
+      timeout: 10000,
     });
+
+    // Navigate to the same week as the previous test
+    const nextBtn = page.locator("button").filter({ has: page.locator("svg.lucide-chevron-right") }).first();
+    for (let i = 0; i < 5; i++) {
+      await nextBtn.click();
+      await page.waitForLoadState("networkidle");
+    }
+
+    // Find the card that has the main recipe we just added
+    const mainRecipeCard = page.locator(".relative").filter({ hasText: TEST_RECIPE_NAME }).first();
+    await expect(mainRecipeCard).toBeVisible({ timeout: 5000 });
+
+    // Click the "Add" button for the side slot in the same card
+    const sideAddBtn = mainRecipeCard.locator("div").filter({ hasText: /^Side$/ }).locator(".. >> button:has-text('Add')");
+    await expect(sideAddBtn).toBeVisible({ timeout: 5000 });
+    await sideAddBtn.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Title should mention "Side"
+    await expect(dialog.getByText("Add Side for")).toBeVisible();
+
+    // Pick the side recipe
+    const recipeOption = dialog.getByText(TEST_SIDE_NAME);
+    await expect(recipeOption).toBeVisible({ timeout: 5000 });
+    await recipeOption.click();
+
+    const addToPlanBtn = dialog.getByRole("button", { name: "Add to Plan" });
+    await expect(addToPlanBtn).toBeVisible({ timeout: 5000 });
+
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/meals/") &&
+        resp.request().method() === "PUT"
+    );
+    await addToPlanBtn.click();
+    await responsePromise;
+
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Both recipes should be visible in the same day card
+    await expect(mainRecipeCard.getByText(TEST_RECIPE_NAME)).toBeVisible({ timeout: 5000 });
+    await expect(mainRecipeCard.getByText(TEST_SIDE_NAME)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should add a custom meal to the dessert slot", async ({ page }) => {
+    await page.goto("/meals");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading meals...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Navigate to the same week
+    const nextBtn = page.locator("button").filter({ has: page.locator("svg.lucide-chevron-right") }).first();
+    for (let i = 0; i < 5; i++) {
+      await nextBtn.click();
+      await page.waitForLoadState("networkidle");
+    }
+
+    // Find the card with both recipes
+    const dayCard = page.locator(".relative").filter({ hasText: TEST_RECIPE_NAME }).first();
+    await expect(dayCard).toBeVisible({ timeout: 5000 });
+
+    // Click "Add" in the dessert slot
+    const dessertAddBtn = dayCard.locator("div").filter({ hasText: /^Dessert$/ }).locator(".. >> button:has-text('Add')");
+    await expect(dessertAddBtn).toBeVisible({ timeout: 5000 });
+    await dessertAddBtn.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Title should mention "Dessert"
+    await expect(dialog.getByText("Add Dessert for")).toBeVisible();
+
+    // Switch to Quick Entry mode
+    await dialog.getByRole("button", { name: "Quick Entry" }).click();
+
+    // Fill custom meal
+    await dialog.getByLabel("What's for dinner?").fill(TEST_CUSTOM_DESSERT);
+
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/meals/") &&
+        resp.request().method() === "PUT"
+    );
+    await dialog.getByRole("button", { name: "Add to Plan" }).click();
+    await responsePromise;
+
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // All three slots should be filled
+    await expect(dayCard.getByText(TEST_SIDE_NAME)).toBeVisible({ timeout: 5000 });
+    await expect(dayCard.getByText(TEST_RECIPE_NAME)).toBeVisible({ timeout: 5000 });
+    await expect(dayCard.getByText(TEST_CUSTOM_DESSERT)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("should clear a single slot without affecting others", async ({ page }) => {
+    await page.goto("/meals");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading meals...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Navigate to the same week
+    const nextBtn = page.locator("button").filter({ has: page.locator("svg.lucide-chevron-right") }).first();
+    for (let i = 0; i < 5; i++) {
+      await nextBtn.click();
+      await page.waitForLoadState("networkidle");
+    }
+
+    // Find the day card with our test recipes
+    const dayCard = page.locator(".relative").filter({ hasText: TEST_RECIPE_NAME }).first();
+    await expect(dayCard).toBeVisible({ timeout: 5000 });
+
+    // Hover over the side recipe to reveal the X button, then click it
+    const sideEntry = dayCard.getByText(TEST_SIDE_NAME);
+    await sideEntry.hover();
+
+    // The X button is in the same group as the side entry
+    const clearBtn = dayCard.locator(".group").filter({ hasText: TEST_SIDE_NAME }).locator("button");
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/meals/") &&
+        resp.url().includes("slot=") &&
+        resp.request().method() === "DELETE"
+    );
+    await clearBtn.click();
+    await responsePromise;
+
+    // Side should be cleared, but main and dessert remain
+    await expect(dayCard.getByText(TEST_SIDE_NAME)).not.toBeVisible({ timeout: 5000 });
+    await expect(dayCard.getByText(TEST_RECIPE_NAME)).toBeVisible();
+    await expect(dayCard.getByText(TEST_CUSTOM_DESSERT)).toBeVisible();
   });
 
   test("should search for a recipe", async ({ page }) => {
@@ -166,17 +379,12 @@ test.describe("Meal Planning", () => {
       timeout: 10000,
     });
 
-    // Use the search input
     const searchInput = page.getByPlaceholder("Search recipes...");
     await searchInput.fill(TEST_RECIPE_NAME);
-
-    // Wait for debounced search
     await page.waitForTimeout(500);
 
-    // Recipe should be visible
     await expect(page.getByText(TEST_RECIPE_NAME)).toBeVisible();
 
-    // Search for something nonexistent
     await searchInput.clear();
     await searchInput.fill("xyznonexistentrecipe99999");
     await page.waitForTimeout(500);
@@ -184,102 +392,5 @@ test.describe("Meal Planning", () => {
     await expect(
       page.getByText("No recipes found matching your search")
     ).toBeVisible();
-  });
-
-  test("should add a meal to the plan from meal page", async ({ page }) => {
-    await page.goto("/meals");
-    await dismissUserPickerIfVisible(page);
-    await expect(page.getByText("Loading meals...")).not.toBeVisible({
-      timeout: 10000,
-    });
-
-    // Click an "Add Meal" button in the week grid
-    const addMealBtn = page.getByRole("button", { name: "Add Meal" }).first();
-    if (await addMealBtn.isVisible().catch(() => false)) {
-      await addMealBtn.click();
-
-      // The recipe picker dialog should appear
-      const dialog = page.getByRole("dialog");
-      await expect(dialog).toBeVisible({ timeout: 5000 });
-
-      // Look for our test recipe in the picker and click it
-      const recipeOption = dialog.getByText(TEST_RECIPE_NAME);
-      if (await recipeOption.isVisible({ timeout: 5000 }).catch(() => false)) {
-        await recipeOption.click();
-
-        // RecipePicker goes to a "confirm" step with scale options
-        // Wait for the confirm view with "Add to Plan" button
-        const addToPlanBtn = dialog.getByRole("button", { name: "Add to Plan" });
-        await expect(addToPlanBtn).toBeVisible({ timeout: 5000 });
-
-        // Click "Add to Plan" to confirm at 1x
-        const responsePromise = page.waitForResponse(
-          (resp) =>
-            resp.url().includes("/api/meals/") &&
-            resp.request().method() === "PUT"
-        );
-        await addToPlanBtn.click();
-        await responsePromise;
-
-        // Dialog should close
-        await expect(dialog).not.toBeVisible({ timeout: 5000 });
-
-        // The recipe name should now appear in the grid
-        await expect(page.getByText(TEST_RECIPE_NAME).first()).toBeVisible({
-          timeout: 5000,
-        });
-      }
-    }
-  });
-
-  test("should view the current week meal plan", async ({ page }) => {
-    await page.goto("/meals");
-    await dismissUserPickerIfVisible(page);
-    await expect(page.getByText("Loading meals...")).not.toBeVisible({
-      timeout: 10000,
-    });
-
-    // The week grid should be visible
-    const gridArea = page.locator(".grid").first();
-    await expect(gridArea).toBeVisible();
-
-    // Verify navigation buttons (chevron icons) are present
-    await expect(
-      page.locator("button").filter({ has: page.locator("svg.lucide-chevron-left") }).first()
-    ).toBeVisible();
-    await expect(
-      page.locator("button").filter({ has: page.locator("svg.lucide-chevron-right") }).first()
-    ).toBeVisible();
-  });
-
-  // Cleanup: delete the test recipe
-  test("should clean up test recipe", async ({ page }) => {
-    await page.goto("/recipes");
-    await dismissUserPickerIfVisible(page);
-    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
-      timeout: 10000,
-    });
-
-    // Click on the recipe card to view details
-    const recipeCard = page.getByText(TEST_RECIPE_NAME);
-    if (await recipeCard.isVisible().catch(() => false)) {
-      await recipeCard.click();
-
-      // Wait for the detail dialog
-      const dialog = page.getByRole("dialog");
-      await expect(dialog).toBeVisible({ timeout: 5000 });
-
-      // Click delete button
-      const deleteBtn = dialog.getByRole("button", { name: "Delete" });
-      if (await deleteBtn.isVisible().catch(() => false)) {
-        // Handle confirm dialog
-        page.on("dialog", async (d) => {
-          await d.accept();
-        });
-
-        await deleteBtn.click();
-        await page.waitForLoadState("networkidle");
-      }
-    }
   });
 });

--- a/e2e/recipe-multiplier.spec.ts
+++ b/e2e/recipe-multiplier.spec.ts
@@ -220,8 +220,9 @@ test.describe.serial("Recipe Multiplier", () => {
       await page.waitForLoadState("networkidle");
     }
 
-    // Click an "Add Meal" button
-    const addMealBtn = page.getByRole("button", { name: "Add Meal" }).first();
+    // Click an "Add" button in a Main slot
+    const mainAddBtns = page.locator("div").filter({ hasText: /^Main$/ }).locator(".. >> button:has-text('Add')");
+    const addMealBtn = mainAddBtns.first();
     await expect(addMealBtn).toBeVisible({ timeout: 5000 });
     await addMealBtn.click();
 

--- a/src/app/api/__tests__/setup.test.ts
+++ b/src/app/api/__tests__/setup.test.ts
@@ -65,6 +65,7 @@ function createTables() {
       prep_time INTEGER,
       cook_time INTEGER,
       servings INTEGER,
+      category TEXT DEFAULT 'main',
       image_url TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP

--- a/src/app/api/meals/[date]/route.ts
+++ b/src/app/api/meals/[date]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { mealPlan, recipes, recipeIngredients } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 
 export const dynamic = "force-dynamic";
 
@@ -12,37 +12,40 @@ export async function GET(
   try {
     const { date } = await params;
 
-    const meal = await db
+    const meals = await db
       .select()
       .from(mealPlan)
-      .where(eq(mealPlan.date, date))
-      .limit(1);
+      .where(eq(mealPlan.date, date));
 
-    if (meal.length === 0) {
-      return NextResponse.json(null);
+    if (meals.length === 0) {
+      return NextResponse.json([]);
     }
 
-    // If there's a recipe, fetch it with ingredients
-    if (meal[0].recipeId) {
-      const recipe = await db
-        .select()
-        .from(recipes)
-        .where(eq(recipes.id, meal[0].recipeId))
-        .limit(1);
+    // Enrich each slot with recipe details if applicable
+    const enriched = await Promise.all(
+      meals.map(async (meal) => {
+        if (!meal.recipeId) return meal;
 
-      const ingredients = await db
-        .select()
-        .from(recipeIngredients)
-        .where(eq(recipeIngredients.recipeId, meal[0].recipeId))
-        .orderBy(recipeIngredients.sortOrder);
+        const recipe = await db
+          .select()
+          .from(recipes)
+          .where(eq(recipes.id, meal.recipeId))
+          .limit(1);
 
-      return NextResponse.json({
-        ...meal[0],
-        recipe: { ...recipe[0], ingredients },
-      });
-    }
+        const ingredients = await db
+          .select()
+          .from(recipeIngredients)
+          .where(eq(recipeIngredients.recipeId, meal.recipeId!))
+          .orderBy(recipeIngredients.sortOrder);
 
-    return NextResponse.json(meal[0]);
+        return {
+          ...meal,
+          recipe: { ...recipe[0], ingredients },
+        };
+      })
+    );
+
+    return NextResponse.json(enriched);
   } catch (error) {
     console.error("Error fetching meal:", error);
     return NextResponse.json(
@@ -59,17 +62,16 @@ export async function PUT(
   try {
     const { date } = await params;
     const body = await request.json();
-    const { recipeId, customMeal, notes, servingsMultiplier } = body;
+    const { recipeId, customMeal, notes, servingsMultiplier, slot = "main" } = body;
 
-    // Check if entry exists for this date
+    // Check if entry exists for this date+slot
     const existing = await db
       .select()
       .from(mealPlan)
-      .where(eq(mealPlan.date, date))
+      .where(and(eq(mealPlan.date, date), eq(mealPlan.slot, slot)))
       .limit(1);
 
     if (existing.length > 0) {
-      // Update existing
       await db
         .update(mealPlan)
         .set({
@@ -78,11 +80,11 @@ export async function PUT(
           customMeal: customMeal || null,
           notes: notes || null,
         })
-        .where(eq(mealPlan.date, date));
+        .where(and(eq(mealPlan.date, date), eq(mealPlan.slot, slot)));
     } else {
-      // Insert new
       await db.insert(mealPlan).values({
         date,
+        slot,
         recipeId: recipeId || null,
         servingsMultiplier: servingsMultiplier ?? 1,
         customMeal: customMeal || null,
@@ -106,8 +108,16 @@ export async function DELETE(
 ) {
   try {
     const { date } = await params;
+    const { searchParams } = new URL(request.url);
+    const slot = searchParams.get("slot");
 
-    await db.delete(mealPlan).where(eq(mealPlan.date, date));
+    if (slot) {
+      await db.delete(mealPlan).where(
+        and(eq(mealPlan.date, date), eq(mealPlan.slot, slot))
+      );
+    } else {
+      await db.delete(mealPlan).where(eq(mealPlan.date, date));
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/src/app/api/meals/route.ts
+++ b/src/app/api/meals/route.ts
@@ -22,6 +22,7 @@ export async function GET(request: Request) {
       .select({
         id: mealPlan.id,
         date: mealPlan.date,
+        slot: mealPlan.slot,
         recipeId: mealPlan.recipeId,
         servingsMultiplier: mealPlan.servingsMultiplier,
         customMeal: mealPlan.customMeal,

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -48,7 +48,7 @@ export async function PUT(
     const { id } = await params;
     const recipeId = parseInt(id);
     const body = await request.json();
-    const { name, description, instructions, prepTime, cookTime, servings, imageUrl, ingredients } = body;
+    const { name, description, instructions, prepTime, cookTime, servings, imageUrl, category, ingredients } = body;
 
     // Update recipe
     const result = await db
@@ -60,6 +60,7 @@ export async function PUT(
         prepTime: prepTime || null,
         cookTime: cookTime || null,
         servings: servings || null,
+        category: category || "main",
         imageUrl: imageUrl || null,
         updatedAt: new Date().toISOString(),
       })

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { name, description, instructions, prepTime, cookTime, servings, imageUrl, ingredients } = body;
+    const { name, description, instructions, prepTime, cookTime, servings, imageUrl, category, ingredients } = body;
 
     if (!name) {
       return NextResponse.json(
@@ -55,6 +55,7 @@ export async function POST(request: Request) {
       prepTime: prepTime || null,
       cookTime: cookTime || null,
       servings: servings || null,
+      category: category || "main",
       imageUrl: imageUrl || null,
     });
 

--- a/src/app/meals/page.tsx
+++ b/src/app/meals/page.tsx
@@ -5,28 +5,22 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight, ShoppingCart, BookOpen } from "lucide-react";
-import { MealDay } from "@/components/meals/MealDay";
+import { MealDay, MealEntry } from "@/components/meals/MealDay";
 import { RecipePicker } from "@/components/meals/RecipePicker";
 import { RecipeDetail } from "@/components/meals/RecipeDetail";
 import { MissingIngredients } from "@/components/meals/MissingIngredients";
 import { Recipe } from "@/components/meals/RecipeCard";
 import { AppLayout } from "@/components/layout/AppLayout";
-
-interface MealEntry {
-  id: number;
-  date: string;
-  recipeId: number | null;
-  servingsMultiplier: number | null;
-  customMeal: string | null;
-  notes: string | null;
-  recipeName: string | null;
-  recipePrepTime: number | null;
-  recipeCookTime: number | null;
-  recipeImageUrl: string | null;
-}
+import { MealSlot, MEAL_SLOTS } from "@/lib/db/schema";
 
 interface RecipeWithIngredients extends Recipe {
   ingredients?: { id: number; recipeId: number; name: string; quantity: string | null; amount: number | null; unit: string | null; section: string | null; sortOrder: number }[];
+}
+
+type DayMeals = Record<MealSlot, MealEntry | null>;
+
+function emptyDayMeals(): DayMeals {
+  return { side: null, main: null, dessert: null };
 }
 
 function getWeekDates(startDate: Date): Date[] {
@@ -52,10 +46,11 @@ function getStartOfWeek(date: Date): Date {
 function MealsContent() {
   const searchParams = useSearchParams();
   const [weekStart, setWeekStart] = useState(() => getStartOfWeek(new Date()));
-  const [meals, setMeals] = useState<Map<string, MealEntry>>(new Map());
+  const [meals, setMeals] = useState<Map<string, DayMeals>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [selectedSlot, setSelectedSlot] = useState<MealSlot>("main");
   const [isIngredientsOpen, setIsIngredientsOpen] = useState(false);
   const [viewingRecipe, setViewingRecipe] = useState<RecipeWithIngredients | null>(null);
   const [isRecipeDetailOpen, setIsRecipeDetailOpen] = useState(false);
@@ -74,9 +69,14 @@ function MealsContent() {
       );
       if (response.ok) {
         const data: MealEntry[] = await response.json();
-        const mealMap = new Map<string, MealEntry>();
+        const mealMap = new Map<string, DayMeals>();
         data.forEach((meal) => {
-          mealMap.set(meal.date, meal);
+          if (!mealMap.has(meal.date)) {
+            mealMap.set(meal.date, emptyDayMeals());
+          }
+          const day = mealMap.get(meal.date)!;
+          const slot = (MEAL_SLOTS.includes(meal.slot as MealSlot) ? meal.slot : "main") as MealSlot;
+          day[slot] = meal;
         });
         setMeals(mealMap);
       }
@@ -97,6 +97,7 @@ function MealsContent() {
     const addRecipeId = searchParams.get("addRecipe");
     if (addRecipeId) {
       setSelectedDate(today);
+      setSelectedSlot("main");
       setIsPickerOpen(true);
       window.history.replaceState({}, "", "/meals");
     }
@@ -118,8 +119,9 @@ function MealsContent() {
     setWeekStart(getStartOfWeek(new Date()));
   };
 
-  const handleAddMeal = (date: Date) => {
+  const handleAddMeal = (date: Date, slot: MealSlot) => {
     setSelectedDate(date);
+    setSelectedSlot(slot);
     setIsPickerOpen(true);
   };
 
@@ -131,7 +133,7 @@ function MealsContent() {
       await fetch(`/api/meals/${dateKey}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ recipeId, servingsMultiplier }),
+        body: JSON.stringify({ recipeId, servingsMultiplier, slot: selectedSlot }),
       });
       setIsPickerOpen(false);
       fetchMeals();
@@ -148,7 +150,7 @@ function MealsContent() {
       await fetch(`/api/meals/${dateKey}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ customMeal: meal, notes }),
+        body: JSON.stringify({ customMeal: meal, notes, slot: selectedSlot }),
       });
       setIsPickerOpen(false);
       fetchMeals();
@@ -157,10 +159,10 @@ function MealsContent() {
     }
   };
 
-  const handleClearMeal = async (date: Date) => {
+  const handleClearMeal = async (date: Date, slot: MealSlot) => {
     const dateKey = formatDateKey(date);
     try {
-      await fetch(`/api/meals/${dateKey}`, {
+      await fetch(`/api/meals/${dateKey}?slot=${slot}`, {
         method: "DELETE",
       });
       fetchMeals();
@@ -238,22 +240,18 @@ function MealsContent() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7 gap-4">
           {weekDates.map((date) => {
             const dateKey = formatDateKey(date);
-            const meal = meals.get(dateKey) || null;
+            const dayMeals = meals.get(dateKey) || emptyDayMeals();
             const isToday = formatDateKey(date) === formatDateKey(today);
 
             return (
               <MealDay
                 key={dateKey}
                 date={date}
-                meal={meal}
+                meals={dayMeals}
                 isToday={isToday}
-                onAddMeal={() => handleAddMeal(date)}
-                onClearMeal={() => handleClearMeal(date)}
-                onViewRecipe={
-                  meal?.recipeId
-                    ? () => handleViewRecipe(meal.recipeId!)
-                    : undefined
-                }
+                onAddMeal={(slot) => handleAddMeal(date, slot)}
+                onClearMeal={(slot) => handleClearMeal(date, slot)}
+                onViewRecipe={handleViewRecipe}
               />
             );
           })}
@@ -266,6 +264,7 @@ function MealsContent() {
         onSelectRecipe={handleSelectRecipe}
         onSelectCustom={handleSelectCustom}
         selectedDate={selectedDate}
+        selectedSlot={selectedSlot}
       />
 
       <RecipeDetail

--- a/src/components/dashboard/TodaysMealCard.tsx
+++ b/src/components/dashboard/TodaysMealCard.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 interface MealEntry {
   id: number;
   date: string;
+  slot: string;
   recipeId: number | null;
   servingsMultiplier: number | null;
   customMeal: string | null;
@@ -18,16 +19,23 @@ interface MealEntry {
   recipeCookTime: number | null;
 }
 
+const SLOT_ORDER = ["side", "main", "dessert"];
+const SLOT_LABELS: Record<string, string> = {
+  side: "Side",
+  main: "Main",
+  dessert: "Dessert",
+};
+
 export function TodaysMealCard() {
-  const [meal, setMeal] = useState<MealEntry | null>(null);
+  const [meals, setMeals] = useState<MealEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     const today = format(new Date(), "yyyy-MM-dd");
     fetch(`/api/meals?start=${today}&end=${today}`)
       .then((r) => r.ok ? r.json() : [])
-      .then((meals: MealEntry[]) => {
-        setMeal(meals.length > 0 ? meals[0] : null);
+      .then((data: MealEntry[]) => {
+        setMeals(data.sort((a, b) => SLOT_ORDER.indexOf(a.slot) - SLOT_ORDER.indexOf(b.slot)));
         setLoaded(true);
       })
       .catch(() => setLoaded(true));
@@ -35,45 +43,52 @@ export function TodaysMealCard() {
 
   if (!loaded) return null;
 
-  const mealName = meal?.recipeName || meal?.customMeal;
-  const totalTime = meal?.recipePrepTime && meal?.recipeCookTime
-    ? meal.recipePrepTime + meal.recipeCookTime
-    : null;
-
   return (
     <Link href="/meals" className="block group">
       <Card className="h-full transition-colors group-hover:border-orange-200 dark:group-hover:border-orange-800">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
             <UtensilsCrossed className="h-4 w-4" />
-            Tonight&apos;s Meal
+            Tonight&apos;s Meals
           </CardTitle>
         </CardHeader>
         <CardContent>
-          {mealName ? (
-            <div className="space-y-1">
-              <p className="text-lg font-semibold leading-tight">{mealName}</p>
-              <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                {totalTime && (
-                  <span className="flex items-center gap-1">
-                    <Clock className="h-3.5 w-3.5" />
-                    {totalTime}m
-                  </span>
-                )}
-                {meal?.servingsMultiplier && meal.servingsMultiplier !== 1 && (
-                  <span className="flex items-center gap-1">
-                    <ChefHat className="h-3.5 w-3.5" />
-                    {meal.servingsMultiplier}x
-                  </span>
-                )}
-              </div>
-              {meal?.notes && (
-                <p className="text-xs text-muted-foreground mt-1">{meal.notes}</p>
-              )}
+          {meals.length > 0 ? (
+            <div className="space-y-1.5">
+              {meals.map((meal) => {
+                const mealName = meal.recipeName || meal.customMeal;
+                const totalTime = meal.recipePrepTime && meal.recipeCookTime
+                  ? meal.recipePrepTime + meal.recipeCookTime
+                  : null;
+
+                return (
+                  <div key={meal.id} className="flex items-baseline gap-2">
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium w-12 flex-shrink-0">
+                      {SLOT_LABELS[meal.slot] || meal.slot}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium leading-tight truncate">
+                        {mealName}
+                        {meal.servingsMultiplier && meal.servingsMultiplier !== 1 && (
+                          <span className="ml-1 text-xs font-normal text-blue-600">
+                            ({meal.servingsMultiplier}x)
+                          </span>
+                        )}
+                      </p>
+                      {totalTime && (
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                          <Clock className="h-3 w-3" />
+                          {totalTime}m
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground italic">
-              No meal planned — tap to add one
+              No meals planned — tap to add one
             </p>
           )}
         </CardContent>

--- a/src/components/meals/MealDay.tsx
+++ b/src/components/meals/MealDay.tsx
@@ -3,10 +3,12 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Clock, Plus, X } from "lucide-react";
+import { MealSlot, MEAL_SLOTS } from "@/lib/db/schema";
 
-interface MealEntry {
+export interface MealEntry {
   id: number;
   date: string;
+  slot: string;
   recipeId: number | null;
   servingsMultiplier?: number | null;
   customMeal: string | null;
@@ -17,18 +19,24 @@ interface MealEntry {
   recipeImageUrl?: string | null;
 }
 
+const SLOT_LABELS: Record<MealSlot, string> = {
+  side: "Side",
+  main: "Main",
+  dessert: "Dessert",
+};
+
 interface MealDayProps {
   date: Date;
-  meal: MealEntry | null;
+  meals: Record<MealSlot, MealEntry | null>;
   isToday: boolean;
-  onAddMeal: () => void;
-  onClearMeal: () => void;
-  onViewRecipe?: () => void;
+  onAddMeal: (slot: MealSlot) => void;
+  onClearMeal: (slot: MealSlot) => void;
+  onViewRecipe: (recipeId: number) => void;
 }
 
 export function MealDay({
   date,
-  meal,
+  meals,
   isToday,
   onAddMeal,
   onClearMeal,
@@ -38,87 +46,80 @@ export function MealDay({
   const dayNum = date.getDate();
   const monthName = date.toLocaleDateString("en-US", { month: "short" });
 
-  const totalTime = meal
-    ? (meal.recipePrepTime || 0) + (meal.recipeCookTime || 0) || null
-    : null;
-
   return (
-    <Card
-      className={`relative ${isToday ? "ring-2 ring-blue-500" : ""}`}
-    >
+    <Card className={`relative ${isToday ? "ring-2 ring-blue-500" : ""}`}>
       <CardContent className="p-3">
-        <div className="flex items-center justify-between mb-2">
-          <div className="flex items-center gap-2">
-            <span
-              className={`text-sm font-medium ${
-                isToday ? "text-blue-600" : "text-muted-foreground"
-              }`}
-            >
-              {dayName}
-            </span>
-            <span className="font-semibold">
-              {monthName} {dayNum}
-            </span>
-          </div>
-          {meal && (
-            <Button
-              size="icon"
-              variant="ghost"
-              className="h-6 w-6 text-muted-foreground hover:text-red-500"
-              onClick={(e) => {
-                e.stopPropagation();
-                onClearMeal();
-              }}
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          )}
+        <div className="flex items-center gap-2 mb-2">
+          <span
+            className={`text-sm font-medium ${
+              isToday ? "text-blue-600" : "text-muted-foreground"
+            }`}
+          >
+            {dayName}
+          </span>
+          <span className="font-semibold">
+            {monthName} {dayNum}
+          </span>
         </div>
 
-        {meal ? (
-          <div
-            className="cursor-pointer hover:bg-gray-50 dark:hover:bg-zinc-800 rounded p-2 -mx-2"
-            onClick={meal.recipeId ? onViewRecipe : undefined}
-          >
-            {meal.recipeImageUrl && (
-              <div className="aspect-video relative bg-gray-100 dark:bg-gray-800 rounded overflow-hidden mb-2">
-                <img
-                  src={meal.recipeImageUrl}
-                  alt={meal.recipeName || ""}
-                  className="object-cover w-full h-full"
-                />
+        <div className="space-y-1.5">
+          {MEAL_SLOTS.map((slot) => {
+            const meal = meals[slot];
+            const totalTime = meal
+              ? (meal.recipePrepTime || 0) + (meal.recipeCookTime || 0) || null
+              : null;
+
+            return (
+              <div key={slot}>
+                <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+                  {SLOT_LABELS[slot]}
+                </div>
+                {meal ? (
+                  <div className="flex items-start gap-1.5 group">
+                    <div
+                      className="flex-1 min-w-0 cursor-pointer rounded px-1.5 py-0.5 -mx-1.5 hover:bg-gray-50 dark:hover:bg-zinc-800"
+                      onClick={meal.recipeId ? () => onViewRecipe(meal.recipeId!) : undefined}
+                    >
+                      <p className="text-sm font-medium line-clamp-1">
+                        {meal.recipeName || meal.customMeal}
+                        {meal.servingsMultiplier && meal.servingsMultiplier !== 1 && (
+                          <span className="ml-1 text-xs font-normal text-blue-600">
+                            ({meal.servingsMultiplier}x)
+                          </span>
+                        )}
+                      </p>
+                      {totalTime && (
+                        <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                          <Clock className="h-2.5 w-2.5" />
+                          <span>{totalTime}m</span>
+                        </div>
+                      )}
+                    </div>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-5 w-5 text-muted-foreground hover:text-red-500 opacity-0 group-hover:opacity-100 flex-shrink-0"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClearMeal(slot);
+                      }}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ) : (
+                  <button
+                    className="w-full text-left text-xs text-muted-foreground hover:text-foreground py-1 px-1.5 -mx-1.5 rounded border border-dashed border-transparent hover:border-gray-300 dark:hover:border-zinc-600"
+                    onClick={() => onAddMeal(slot)}
+                  >
+                    <Plus className="h-3 w-3 inline mr-0.5" />
+                    Add
+                  </button>
+                )}
               </div>
-            )}
-            <p className="font-medium line-clamp-2">
-              {meal.recipeName || meal.customMeal}
-              {meal.servingsMultiplier && meal.servingsMultiplier !== 1 && (
-                <span className="ml-1 text-xs font-normal text-blue-600">
-                  ({meal.servingsMultiplier}x)
-                </span>
-              )}
-            </p>
-            {totalTime && (
-              <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
-                <Clock className="h-3 w-3" />
-                <span>{totalTime} min</span>
-              </div>
-            )}
-            {meal.notes && (
-              <p className="text-xs text-muted-foreground mt-1 line-clamp-1">
-                {meal.notes}
-              </p>
-            )}
-          </div>
-        ) : (
-          <Button
-            variant="ghost"
-            className="w-full h-20 border-2 border-dashed text-muted-foreground hover:text-foreground hover:border-solid"
-            onClick={onAddMeal}
-          >
-            <Plus className="h-5 w-5 mr-1" />
-            Add Meal
-          </Button>
-        )}
+            );
+          })}
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/components/meals/RecipeCard.tsx
+++ b/src/components/meals/RecipeCard.tsx
@@ -11,6 +11,7 @@ export interface Recipe {
   prepTime: number | null;
   cookTime: number | null;
   servings: number | null;
+  category: string | null;
   imageUrl: string | null;
   createdAt: string | null;
   updatedAt: string | null;

--- a/src/components/meals/RecipeForm.tsx
+++ b/src/components/meals/RecipeForm.tsx
@@ -63,6 +63,7 @@ export function RecipeForm({
   const [prepTime, setPrepTime] = useState("");
   const [cookTime, setCookTime] = useState("");
   const [servings, setServings] = useState("");
+  const [category, setCategory] = useState("main");
   const [imageUrl, setImageUrl] = useState("");
   const [ingredients, setIngredients] = useState<Ingredient[]>([
     { name: "", amount: "", unit: "", section: "" },
@@ -77,6 +78,7 @@ export function RecipeForm({
       setPrepTime(recipe.prepTime?.toString() || "");
       setCookTime(recipe.cookTime?.toString() || "");
       setServings(recipe.servings?.toString() || "");
+      setCategory(recipe.category || "main");
       setImageUrl(recipe.imageUrl || "");
       setIngredients(
         recipe.ingredients?.map((i) => {
@@ -118,6 +120,7 @@ export function RecipeForm({
       setPrepTime("");
       setCookTime("");
       setServings("");
+      setCategory("main");
       setImageUrl("");
       setIngredients([{ name: "", amount: "", unit: "", section: "" }]);
     }
@@ -178,6 +181,7 @@ export function RecipeForm({
         prepTime: prepTime ? parseInt(prepTime) : null,
         cookTime: cookTime ? parseInt(cookTime) : null,
         servings: servings ? parseInt(servings) : null,
+        category,
         imageUrl: imageUrl.trim() || null,
         ingredients: ingredients
           .filter((i) => i.name.trim())
@@ -344,7 +348,7 @@ export function RecipeForm({
             />
           </div>
 
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-4 gap-4">
             <div className="space-y-2">
               <Label htmlFor="prepTime">Prep Time (min)</Label>
               <Input
@@ -374,6 +378,19 @@ export function RecipeForm({
                 onChange={(e) => setServings(e.target.value)}
                 placeholder="4"
               />
+            </div>
+            <div className="space-y-2">
+              <Label>Category</Label>
+              <Select value={category} onValueChange={setCategory}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="main">Main</SelectItem>
+                  <SelectItem value="side">Side</SelectItem>
+                  <SelectItem value="dessert">Dessert</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
 

--- a/src/components/meals/RecipePicker.tsx
+++ b/src/components/meals/RecipePicker.tsx
@@ -22,6 +22,7 @@ interface RecipePickerProps {
   onSelectRecipe: (recipeId: number, servingsMultiplier: number) => void;
   onSelectCustom: (meal: string, notes?: string) => void;
   selectedDate: Date | null;
+  selectedSlot?: string;
 }
 
 export function RecipePicker({
@@ -30,6 +31,7 @@ export function RecipePicker({
   onSelectRecipe,
   onSelectCustom,
   selectedDate,
+  selectedSlot,
 }: RecipePickerProps) {
   const [recipes, setRecipes] = useState<Recipe[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -113,7 +115,7 @@ export function RecipePicker({
         <DialogHeader>
           <DialogTitle>
             {selectedDate
-              ? `Add Meal for ${formatDate(selectedDate)}`
+              ? `Add ${selectedSlot ? selectedSlot.charAt(0).toUpperCase() + selectedSlot.slice(1) : "Meal"} for ${formatDate(selectedDate)}`
               : "Add Meal"}
           </DialogTitle>
         </DialogHeader>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -127,11 +127,13 @@ function initDb(): BetterSQLite3Database<typeof schema> {
 
     CREATE TABLE IF NOT EXISTS meal_plan (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      date TEXT NOT NULL UNIQUE,
+      date TEXT NOT NULL,
+      slot TEXT NOT NULL DEFAULT 'main',
       recipe_id INTEGER REFERENCES recipes(id),
       custom_meal TEXT,
       notes TEXT,
-      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(date, slot)
     );
 
     CREATE TABLE IF NOT EXISTS activities (
@@ -283,6 +285,14 @@ function initDb(): BetterSQLite3Database<typeof schema> {
     sqlite.exec(`ALTER TABLE meal_plan ADD COLUMN servings_multiplier REAL DEFAULT 1`);
   } catch { /* column already exists */ }
 
+  // Recipe category (side/main/dessert)
+  try {
+    sqlite.exec(`ALTER TABLE recipes ADD COLUMN category TEXT DEFAULT 'main'`);
+  } catch { /* column already exists */ }
+
+  // Meal plan slot column + unique constraint migration
+  migrateMealPlanSlots(sqlite);
+
   // Recipe ingredient structured fields
   try {
     sqlite.exec(`ALTER TABLE recipe_ingredients ADD COLUMN amount REAL`);
@@ -310,6 +320,33 @@ export const db = new Proxy({} as BetterSQLite3Database<typeof schema>, {
     return (realDb as unknown as Record<string | symbol, unknown>)[prop];
   },
 });
+
+function migrateMealPlanSlots(sqlite: Database.Database) {
+  // Check if the slot column already exists
+  const columns = sqlite
+    .prepare(`PRAGMA table_info(meal_plan)`)
+    .all() as { name: string }[];
+  if (columns.some((c) => c.name === "slot")) return;
+
+  // Table-swap migration: add slot column, change unique from (date) to (date, slot)
+  sqlite.exec(`
+    CREATE TABLE meal_plan_new (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      date TEXT NOT NULL,
+      slot TEXT NOT NULL DEFAULT 'main',
+      recipe_id INTEGER REFERENCES recipes(id),
+      servings_multiplier REAL DEFAULT 1,
+      custom_meal TEXT,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(date, slot)
+    );
+    INSERT INTO meal_plan_new (id, date, slot, recipe_id, servings_multiplier, custom_meal, notes, created_at)
+      SELECT id, date, 'main', recipe_id, servings_multiplier, custom_meal, notes, created_at FROM meal_plan;
+    DROP TABLE meal_plan;
+    ALTER TABLE meal_plan_new RENAME TO meal_plan;
+  `);
+}
 
 function migrateLegacyQuantities(sqlite: Database.Database) {
   // Only migrate rows that have quantity but no amount

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -87,6 +87,9 @@ export const itemHistory = sqliteTable("item_history", {
   lastUsed: text("last_used").default("CURRENT_TIMESTAMP"),
 });
 
+export const MEAL_SLOTS = ["side", "main", "dessert"] as const;
+export type MealSlot = (typeof MEAL_SLOTS)[number];
+
 export const recipes = sqliteTable("recipes", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   name: text("name").notNull(),
@@ -95,6 +98,7 @@ export const recipes = sqliteTable("recipes", {
   prepTime: integer("prep_time"),
   cookTime: integer("cook_time"),
   servings: integer("servings"),
+  category: text("category").default("main"),
   imageUrl: text("image_url"),
   createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
   updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
@@ -115,7 +119,8 @@ export const recipeIngredients = sqliteTable("recipe_ingredients", {
 
 export const mealPlan = sqliteTable("meal_plan", {
   id: integer("id").primaryKey({ autoIncrement: true }),
-  date: text("date").notNull().unique(),
+  date: text("date").notNull(),
+  slot: text("slot").notNull().default("main"),
   recipeId: integer("recipe_id").references(() => recipes.id),
   servingsMultiplier: real("servings_multiplier").default(1),
   customMeal: text("custom_meal"),

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -203,9 +203,10 @@ export function createMcpServer(baseUrl: string) {
 
   server.tool(
     "set_meal",
-    "Set or update the meal for a specific date.",
+    "Set or update the meal for a specific date and slot.",
     {
       date: z.string().describe("Date (ISO format, e.g. 2026-04-07)"),
+      slot: z.enum(["side", "main", "dessert"]).default("main").describe("Meal slot"),
       recipeId: z.number().optional().describe("Recipe ID (use this OR customMeal)"),
       customMeal: z.string().optional().describe("Custom meal name (use this OR recipeId)"),
       notes: z.string().optional(),
@@ -216,9 +217,13 @@ export function createMcpServer(baseUrl: string) {
 
   server.tool(
     "delete_meal",
-    "Remove the meal plan entry for a specific date.",
-    { date: z.string().describe("Date (ISO format)") },
-    async ({ date }) => text(await api(`/api/meals/${date}`, { method: "DELETE" }))
+    "Remove a meal plan entry. Specify slot to delete one slot, or omit to clear the whole day.",
+    {
+      date: z.string().describe("Date (ISO format)"),
+      slot: z.enum(["side", "main", "dessert"]).optional().describe("Meal slot to delete (omit to clear all)"),
+    },
+    async ({ date, slot }) =>
+      text(await api(`/api/meals/${date}${slot ? `?slot=${slot}` : ""}`, { method: "DELETE" }))
   );
 
   server.tool(


### PR DESCRIPTION
## Summary
- Adds meal slots (side, main, dessert) to the meal planner — each day can now have up to 3 meals
- Adds `category` field to recipes (side/main/dessert) with a selector in the recipe form
- Migrates existing meal plan data to the "main" slot automatically
- Updates dashboard widget, MCP tools, and API routes for slot-aware operations

## Changes
- **Schema**: `slot` column on `meal_plan` with `UNIQUE(date, slot)`, `category` column on `recipes`
- **Migration**: table-swap migration for existing databases, all current meals default to "main"
- **API**: `GET/PUT/DELETE /api/meals/[date]` now slot-aware, `POST/PUT /api/recipes` accepts category
- **UI**: MealDay shows 3 slot rows, RecipePicker shows slot in title, RecipeForm has category selector
- **MCP**: `set_meal` and `delete_meal` accept `slot` parameter

## Test plan
- [x] Unit tests pass (36/36)
- [x] Week view shows Side/Main/Dessert labels — [proof](https://github.com/heuwels/tuis/pull/32#issuecomment-4251740837)
- [x] Slot-aware picker dialog (title shows slot name) — [proof](https://github.com/heuwels/tuis/pull/32#issuecomment-4251741926)
- [x] Add recipe to main slot
- [x] Add side recipe to same day
- [x] Add custom dessert to same day — [proof](https://github.com/heuwels/tuis/pull/32#issuecomment-4251742834)
- [x] API returns 3 separate rows per date with distinct slots — [proof](https://github.com/heuwels/tuis/pull/32#issuecomment-4251742834)
- [ ] Clear one slot without affecting others (e2e covers this)
- [x] Week navigation still works
- [x] Recipe search still works

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)