### PR TITLE
Fix complete-on-date calendar rendering in top corner

### DIFF
--- a/src/components/dashboard/CompleteButton.tsx
+++ b/src/components/dashboard/CompleteButton.tsx
@@ -4,10 +4,11 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -88,20 +89,20 @@ export function CompleteButton({ taskId, taskName, onComplete }: CompleteButtonP
         </DropdownMenu>
       </div>
 
-      <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
-        <PopoverTrigger asChild>
-          <span className="hidden" />
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="end">
+      <Dialog open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
+        <DialogContent className="w-auto p-0 sm:max-w-fit">
+          <DialogHeader className="px-4 pt-4 pb-0">
+            <DialogTitle className="text-sm font-medium">Complete on date</DialogTitle>
+          </DialogHeader>
           <Calendar
             mode="single"
             selected={new Date()}
             onSelect={(date) => date && completeTask(date)}
             disabled={(date) => date > new Date()}
-            initialFocus
+            autoFocus
           />
-        </PopoverContent>
-      </Popover>
+        </DialogContent>
+      </Dialog>
 
       <CompletionDetailsDialog
         taskId={taskId}


### PR DESCRIPTION
## Summary
- Fix "complete on date" calendar popping up in the top corner and immediately closing
- The Popover used a hidden `<span>` as its anchor, giving it no position (rendered at 0,0)
- The dropdown menu closing also triggered a click-outside event on the popover, auto-closing it
- Replaced with a Dialog which centers on screen and doesn't need an anchor element

## Test plan
- [ ] Click chevron on an overdue chore > "Complete on date..." opens a centered calendar dialog
- [ ] Selecting a date completes the chore with that date
- [ ] Clicking outside or X closes the dialog without completing

🤖 Generated with [Claude Code](https://claude.com/claude-code)