### PR TITLE
Add recipe photo uploads with local filesystem storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@
 *.db-shm
 *.db-wal
 
+# uploads
+/uploads
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ COPY --from=builder /app/mcp-server/dist ./mcp-server/dist
 COPY --from=builder /app/mcp-server/node_modules ./mcp-server/node_modules
 COPY --from=builder /app/mcp-server/package.json ./mcp-server/package.json
 
-# Create data directory for SQLite and set permissions
-RUN mkdir -p /app/data && chown -R nextjs:nodejs /app
+# Create data directory for SQLite and uploads, set permissions
+RUN mkdir -p /app/data/uploads && chown -R nextjs:nodejs /app
 
 USER nextjs
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -26,3 +26,6 @@ NEXTAUTH_SECRET=
 # Error tracking (opt-in) — works with Sentry or GlitchTip, just set the DSN.
 # Leave empty or omit to disable error tracking entirely.
 NEXT_PUBLIC_SENTRY_DSN=
+
+# File uploads — max size in MB (default: 10)
+# MAX_UPLOAD_SIZE_MB=10

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { get } from "@/lib/storage";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  try {
+    const { path } = await params;
+    const key = path.join("/");
+
+    // Block path traversal
+    if (key.includes("..")) {
+      return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+    }
+
+    const file = get(key);
+    if (!file) {
+      return new NextResponse("Not found", { status: 404 });
+    }
+
+    return new NextResponse(file.data, {
+      headers: {
+        "Content-Type": file.contentType,
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    });
+  } catch (error) {
+    console.error("Error serving file:", error);
+    return new NextResponse("Internal error", { status: 500 });
+  }
+}

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { put } from "@/lib/storage";
+
+export const dynamic = "force-dynamic";
+
+const MAX_SIZE = (parseInt(process.env.MAX_UPLOAD_SIZE_MB || "10") || 10) * 1024 * 1024;
+
+const ALLOWED_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "application/pdf",
+]);
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    const category = (formData.get("category") as string) || "general";
+
+    if (!file) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    if (!ALLOWED_TYPES.has(file.type)) {
+      return NextResponse.json(
+        { error: `File type not allowed: ${file.type}` },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json(
+        { error: `File exceeds maximum size of ${MAX_SIZE / 1024 / 1024}MB` },
+        { status: 400 }
+      );
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const key = put(category, file.name, buffer);
+
+    return NextResponse.json({
+      key,
+      url: `/api/uploads/${key}`,
+    });
+  } catch (error) {
+    console.error("Upload error:", error);
+    return NextResponse.json(
+      { error: "Upload failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/meals/RecipeCard.tsx
+++ b/src/components/meals/RecipeCard.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Clock, Users } from "lucide-react";
+import { resolveFileUrl } from "@/lib/file-url";
 
 export interface Recipe {
   id: number;
@@ -34,7 +35,7 @@ export function RecipeCard({ recipe, onClick }: RecipeCardProps) {
       {recipe.imageUrl && (
         <div className="aspect-video relative bg-gray-100 dark:bg-gray-800">
           <img
-            src={recipe.imageUrl}
+            src={resolveFileUrl(recipe.imageUrl) || ""}
             alt={recipe.name}
             className="object-cover w-full h-full"
           />

--- a/src/components/meals/RecipeDetail.tsx
+++ b/src/components/meals/RecipeDetail.tsx
@@ -19,6 +19,7 @@ import {
   Check,
 } from "lucide-react";
 import { Recipe } from "./RecipeCard";
+import { resolveFileUrl } from "@/lib/file-url";
 import {
   IngredientUnit,
   scaleAmount,
@@ -240,7 +241,7 @@ export function RecipeDetail({
         {recipe.imageUrl && (
           <div className="aspect-video relative bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden -mx-6">
             <img
-              src={recipe.imageUrl}
+              src={resolveFileUrl(recipe.imageUrl) || ""}
               alt={recipe.name}
               className="object-cover w-full h-full"
             />

--- a/src/components/meals/RecipeForm.tsx
+++ b/src/components/meals/RecipeForm.tsx
@@ -18,7 +18,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Trash2, GripVertical, SeparatorHorizontal } from "lucide-react";
+import { Plus, Trash2, GripVertical, SeparatorHorizontal, Upload, X, Link as LinkIcon } from "lucide-react";
+import { resolveFileUrl } from "@/lib/file-url";
 import { Recipe } from "./RecipeCard";
 import {
   UNITS,
@@ -65,6 +66,8 @@ export function RecipeForm({
   const [servings, setServings] = useState("");
   const [category, setCategory] = useState("main");
   const [imageUrl, setImageUrl] = useState("");
+  const [isUploading, setIsUploading] = useState(false);
+  const [useUrlMode, setUseUrlMode] = useState(false);
   const [ingredients, setIngredients] = useState<Ingredient[]>([
     { name: "", amount: "", unit: "", section: "" },
   ]);
@@ -80,6 +83,7 @@ export function RecipeForm({
       setServings(recipe.servings?.toString() || "");
       setCategory(recipe.category || "main");
       setImageUrl(recipe.imageUrl || "");
+      setUseUrlMode(recipe.imageUrl?.startsWith("http") || false);
       setIngredients(
         recipe.ingredients?.map((i) => {
           // If structured data exists, use it
@@ -122,6 +126,7 @@ export function RecipeForm({
       setServings("");
       setCategory("main");
       setImageUrl("");
+      setUseUrlMode(false);
       setIngredients([{ name: "", amount: "", unit: "", section: "" }]);
     }
   }, [recipe, open]);
@@ -395,13 +400,89 @@ export function RecipeForm({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="imageUrl">Image URL</Label>
-            <Input
-              id="imageUrl"
-              value={imageUrl}
-              onChange={(e) => setImageUrl(e.target.value)}
-              placeholder="https://..."
-            />
+            <div className="flex items-center justify-between">
+              <Label>Photo</Label>
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                onClick={() => {
+                  setUseUrlMode(!useUrlMode);
+                  if (!useUrlMode) setImageUrl("");
+                }}
+              >
+                {useUrlMode ? (
+                  <><Upload className="h-3 w-3" /> Upload instead</>
+                ) : (
+                  <><LinkIcon className="h-3 w-3" /> Use URL instead</>
+                )}
+              </button>
+            </div>
+            {useUrlMode ? (
+              <Input
+                value={imageUrl}
+                onChange={(e) => setImageUrl(e.target.value)}
+                placeholder="https://..."
+              />
+            ) : (
+              <div>
+                {imageUrl && !imageUrl.startsWith("http") ? (
+                  <div className="relative rounded-lg overflow-hidden border bg-gray-50 dark:bg-zinc-900">
+                    <img
+                      src={resolveFileUrl(imageUrl) || ""}
+                      alt="Recipe"
+                      className="w-full h-32 object-cover"
+                    />
+                    <button
+                      type="button"
+                      className="absolute top-1 right-1 bg-black/60 text-white rounded-full p-1 hover:bg-black/80"
+                      onClick={() => setImageUrl("")}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ) : (
+                  <label className="flex flex-col items-center justify-center w-full h-24 border-2 border-dashed rounded-lg cursor-pointer hover:border-gray-400 dark:hover:border-zinc-500 transition-colors">
+                    <input
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      disabled={isUploading}
+                      onChange={async (e) => {
+                        const file = e.target.files?.[0];
+                        if (!file) return;
+                        setIsUploading(true);
+                        try {
+                          const formData = new FormData();
+                          formData.append("file", file);
+                          formData.append("category", "recipes");
+                          const res = await fetch("/api/uploads", {
+                            method: "POST",
+                            body: formData,
+                          });
+                          if (res.ok) {
+                            const { key } = await res.json();
+                            setImageUrl(key);
+                          }
+                        } catch (err) {
+                          console.error("Upload failed:", err);
+                        } finally {
+                          setIsUploading(false);
+                          e.target.value = "";
+                        }
+                      }}
+                    />
+                    {isUploading ? (
+                      <span className="text-sm text-muted-foreground">Uploading...</span>
+                    ) : (
+                      <>
+                        <Upload className="h-5 w-5 text-muted-foreground mb-1" />
+                        <span className="text-sm text-muted-foreground">Click to upload photo</span>
+                      </>
+                    )}
+                  </label>
+                )}
+              </div>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/src/components/meals/RecipePicker.tsx
+++ b/src/components/meals/RecipePicker.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Search, ChefHat, Clock, Users, ArrowLeft } from "lucide-react";
 import { Recipe } from "./RecipeCard";
+import { resolveFileUrl } from "@/lib/file-url";
 
 const SCALE_OPTIONS = [0.5, 1, 1.5, 2];
 
@@ -151,7 +152,7 @@ export function RecipePicker({
               {selectedRecipeForConfirm.imageUrl ? (
                 <div className="w-16 h-16 rounded overflow-hidden bg-gray-100 dark:bg-gray-800 flex-shrink-0">
                   <img
-                    src={selectedRecipeForConfirm.imageUrl}
+                    src={resolveFileUrl(selectedRecipeForConfirm.imageUrl) || ""}
                     alt={selectedRecipeForConfirm.name}
                     className="object-cover w-full h-full"
                   />
@@ -239,7 +240,7 @@ export function RecipePicker({
                         {recipe.imageUrl ? (
                           <div className="w-16 h-16 rounded overflow-hidden bg-gray-100 dark:bg-gray-800 flex-shrink-0">
                             <img
-                              src={recipe.imageUrl}
+                              src={resolveFileUrl(recipe.imageUrl) || ""}
                               alt={recipe.name}
                               className="object-cover w-full h-full"
                             />

--- a/src/lib/file-url.ts
+++ b/src/lib/file-url.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolve a storage key or external URL to a servable URL.
+ * Works on both client and server (pure string logic, no Node imports).
+ */
+export function resolveFileUrl(keyOrUrl: string | null | undefined): string | null {
+  if (!keyOrUrl) return null;
+  if (keyOrUrl.startsWith("http://") || keyOrUrl.startsWith("https://")) return keyOrUrl;
+  return `/api/uploads/${keyOrUrl}`;
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+
+const MIME_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".pdf": "application/pdf",
+};
+
+const ALLOWED_EXTENSIONS = new Set(Object.keys(MIME_TYPES));
+
+function getUploadRoot(): string {
+  const dataDir = fs.existsSync("/app/data") ? "/app/data" : process.cwd();
+  return path.join(dataDir, "uploads");
+}
+
+function safePath(key: string): string | null {
+  const root = getUploadRoot();
+  const resolved = path.resolve(root, key);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) return null;
+  return resolved;
+}
+
+export function put(category: string, filename: string, data: Buffer): string {
+  const ext = path.extname(filename).toLowerCase();
+  if (!ALLOWED_EXTENSIONS.has(ext)) {
+    throw new Error(`Disallowed file extension: ${ext}`);
+  }
+
+  const root = getUploadRoot();
+  const dir = path.join(root, category);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const id = `${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
+  const key = `${category}/${id}${ext}`;
+  const fullPath = path.join(root, key);
+
+  fs.writeFileSync(fullPath, data);
+  return key;
+}
+
+export function get(key: string): { data: Buffer; contentType: string } | null {
+  const fullPath = safePath(key);
+  if (!fullPath || !fs.existsSync(fullPath)) return null;
+
+  const ext = path.extname(fullPath).toLowerCase();
+  const contentType = MIME_TYPES[ext] || "application/octet-stream";
+  return { data: fs.readFileSync(fullPath), contentType };
+}
+
+export function remove(key: string): void {
+  const fullPath = safePath(key);
+  if (fullPath && fs.existsSync(fullPath)) {
+    fs.unlinkSync(fullPath);
+  }
+}


### PR DESCRIPTION
## Summary
- Add local filesystem file storage for recipe photo uploads
- Uses the existing `/app/data` Docker volume — uploads go to `/app/data/uploads/`
- Recipes can now have photos uploaded directly via the form, or continue using external URLs
- All image rendering updated to resolve storage keys through `/api/uploads/`

## Changes
- **Storage lib** (`src/lib/storage.ts`): put/get/delete with path traversal protection, allowed file types (images + PDF)
- **Upload API** (`POST /api/uploads`): multipart form data, validates type and size (10MB default, configurable via `MAX_UPLOAD_SIZE_MB`)
- **File serving** (`GET /api/uploads/[...path]`): streams files with immutable cache headers
- **URL resolver** (`src/lib/file-url.ts`): resolves storage keys or external URLs — works on client and server
- **RecipeForm**: file upload area with preview, remove button, and "Use URL instead" toggle
- **RecipeCard, RecipeDetail, RecipePicker**: all use `resolveFileUrl()` for image src
- **Dockerfile**: creates `/app/data/uploads` directory
- **`.gitignore`**: excludes `/uploads`

## Test plan
- [x] Unit tests pass (44/44)
- [x] Lint clean (0 errors)
- [ ] Upload a photo to a new recipe — preview shows in form
- [ ] Submit recipe — image displays on recipe card and detail view
- [ ] Edit recipe — existing upload shown, can replace or remove
- [ ] "Use URL instead" toggle — external URLs still work
- [ ] Existing recipes with external URLs render correctly (no regression)

Partial implementation of #23 — local FS driver for recipe photos. Appliance manuals and S3/R2 drivers to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)