### PR TITLE
Add type checking and build to CI, fix all TS errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,28 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +50,7 @@ jobs:
       - run: npm test
 
   e2e-tests:
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/app/api/__tests__/quotes.test.ts
+++ b/src/app/api/__tests__/quotes.test.ts
@@ -90,8 +90,9 @@ afterEach(() => {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function makeRequest(url: string, init?: RequestInit): Request {
-  return new Request(`http://localhost${url}`, init);
+// Route handlers expect NextRequest but Request works at runtime
+function makeRequest(url: string, init?: RequestInit) {
+  return new Request(`http://localhost${url}`, init) as unknown as import("next/server").NextRequest;
 }
 
 function jsonBody(data: Record<string, unknown>): RequestInit {

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -21,7 +21,7 @@ export async function GET(
       return new NextResponse("Not found", { status: 404 });
     }
 
-    return new NextResponse(file.data, {
+    return new NextResponse(new Uint8Array(file.data), {
       headers: {
         "Content-Type": file.contentType,
         "Cache-Control": "public, max-age=31536000, immutable",


### PR DESCRIPTION
## Summary
- Add `tsc --noEmit` type checking job to CI
- Add `next build` job to CI — catches build errors before merge
- E2e tests now depend on build passing first
- Fix all existing TypeScript errors (zero errors from `tsc --noEmit`)

## Changes
- **CI workflow**: Added `typecheck` and `build` jobs. Lint, typecheck, build, and unit tests run in parallel. E2e depends on build.
- **Uploads route**: Fix `Buffer` not assignable to `BodyInit` — wrap with `new Uint8Array()`
- **Quotes test**: Fix `Request` vs `NextRequest` type mismatch — cast via helper function

## Test plan
- [x] `tsc --noEmit` passes with 0 errors
- [x] Unit tests pass (44/44)
- [ ] CI runs all 5 jobs: lint, typecheck, build, unit-tests, e2e-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)