### PR TITLE
Fix task table columns compressed to screen width

### DIFF
--- a/src/components/tasks/TaskTable.tsx
+++ b/src/components/tasks/TaskTable.tsx
@@ -44,7 +44,7 @@ export function TaskTable({ tasks, onTaskComplete, onEdit, onDelete, onView }: T
 
   return (
     <div className="rounded-md border overflow-x-auto">
-      <Table className="table-fixed w-full">
+      <Table>
         <TableHeader>
           <TableRow>
             <TableHead className="min-w-[200px] max-w-[300px]">Task</TableHead>


### PR DESCRIPTION
## Summary
- Remove `table-fixed` from the task table so columns size based on content rather than being compressed to viewport width
- The existing `overflow-x-auto` container handles horizontal scrolling when the table is wider than the screen

## Test plan
- [x] Task table columns render at content-appropriate widths
- [x] Horizontal scroll works when table exceeds viewport

### Proof: Table renders with proper column widths

![Task table with proper column widths](https://docs.lukeboyle.com/proof/2026-04-17/task-table-fix-fullwidth-6fe750b7.png)

Verified that removing `table-fixed` allows columns to size based on content, with horizontal scroll when the table exceeds viewport width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
