### PR TITLE
Add CLI, PAT auth, and token management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # dependencies
 /node_modules
+/cli/node_modules
+/mcp-server/node_modules
 /.pnp
 .pnp.*
 .yarn/*
@@ -22,6 +24,8 @@
 
 # production
 /build
+/cli/dist
+/mcp-server/dist
 
 # misc
 .DS_Store

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,97 @@
+# tuis-cli
+
+Command-line interface for the [Tuis](https://github.com/heuwels/tuis) household management app.
+
+## Setup
+
+```bash
+cd cli
+npm install
+npm run build
+```
+
+To make the `tuis` command available globally:
+
+```bash
+npm link
+```
+
+## Configuration
+
+Before using the CLI, configure your server URL and access token:
+
+```bash
+tuis configure
+```
+
+You'll be prompted for:
+- **Server URL** — e.g. `http://localhost:3000` or `https://chores.home.example.com`
+- **Access token** — create one in Settings > Personal Access Tokens
+
+Config is stored in `~/.config/tuis/config.json` with restricted permissions.
+
+## Usage
+
+```bash
+tuis <resource> <command> [options]
+```
+
+### Resources
+
+| Resource | Commands |
+|----------|----------|
+| `tasks` | `list`, `get`, `create`, `update`, `delete`, `complete` |
+| `shopping lists` | `list`, `create`, `delete` |
+| `shopping items` | `add`, `update`, `delete` |
+| `recipes` | `list`, `get`, `create`, `update`, `delete` |
+| `meals` | `list`, `get`, `set`, `delete` |
+| `vehicles` | `list`, `get`, `create`, `update`, `delete` |
+| `vehicles fuel` | `list`, `add` |
+| `vehicles services` | `list`, `add` |
+| `vendors` | `list`, `get`, `create`, `update`, `delete` |
+| `quotes` | `list`, `get`, `create`, `update`, `delete` |
+| `appliances` | `list`, `get`, `create`, `update`, `delete` |
+| `activities` | `list`, `get`, `create`, `update`, `delete` |
+| `users` | `list`, `create`, `delete` |
+| `stats` | _(shows household stats)_ |
+
+### Examples
+
+```bash
+# List all tasks
+tuis tasks list
+
+# Create a task
+tuis tasks create --name "Clean gutters" --area Outdoor --frequency Quarterly
+
+# Mark a task complete
+tuis tasks complete 5
+
+# Add a shopping item
+tuis shopping items add --list 1 --name "Milk" --quantity "2L"
+
+# List vehicles as JSON
+tuis vehicles list --json
+
+# Log fuel
+tuis vehicles fuel add 1 --date 2026-04-19 --odometer 45000 --litres 42.5 --cost 89.50
+
+# View stats
+tuis stats
+```
+
+### Output formats
+
+List commands default to a table view. Use `--json` for JSON output:
+
+```bash
+tuis tasks list          # table
+tuis tasks list --json   # JSON
+tuis tasks get 5         # always JSON (single item)
+```
+
+## Authentication
+
+The CLI uses Personal Access Tokens (PATs) for authentication. Tokens are created in the Tuis web UI under Settings > Personal Access Tokens.
+
+Each token has scopes that control which endpoints it can access (e.g. `tasks:read`, `tasks:write`). The CLI sends the token as a `Bearer` header with every request.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,605 @@
+{
+  "name": "tuis-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tuis-cli",
+      "version": "1.0.0",
+      "dependencies": {
+        "commander": "^13.1.0"
+      },
+      "bin": {
+        "tuis": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "tsx": "^4.21.0",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "tuis-cli",
+  "version": "1.0.0",
+  "description": "CLI for the Tuis household management app",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "tuis": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "commander": "^13.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "tsx": "^4.21.0",
+    "typescript": "^5"
+  }
+}

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -7,14 +7,22 @@ export async function api(
   const config = requireConfig();
   const url = `${config.url.replace(/\/$/, "")}${path}`;
 
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${config.token}`,
-      ...options?.headers,
-    },
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.token}`,
+        ...options?.headers,
+      },
+    });
+  } catch (err) {
+    const msg =
+      err instanceof Error ? err.message : "Unknown network error";
+    console.error(`Cannot connect to ${config.url}: ${msg}`);
+    process.exit(1);
+  }
 
   if (!res.ok) {
     const body = await res.text();
@@ -29,7 +37,13 @@ export async function api(
     process.exit(1);
   }
 
-  return res.json();
+  const text = await res.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { message: text };
+  }
 }
 
 export function printJson(data: unknown): void {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -1,0 +1,65 @@
+import { requireConfig } from "./config.js";
+
+export async function api(
+  path: string,
+  options?: RequestInit
+): Promise<unknown> {
+  const config = requireConfig();
+  const url = `${config.url.replace(/\/$/, "")}${path}`;
+
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.token}`,
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    let message: string;
+    try {
+      const json = JSON.parse(body);
+      message = json.error || body;
+    } catch {
+      message = body;
+    }
+    console.error(`Error ${res.status}: ${message}`);
+    process.exit(1);
+  }
+
+  return res.json();
+}
+
+export function printJson(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+export function printTable(
+  items: Record<string, unknown>[],
+  columns: { key: string; label: string; width?: number }[]
+): void {
+  if (items.length === 0) {
+    console.log("No results.");
+    return;
+  }
+
+  // Header
+  const header = columns
+    .map((c) => c.label.padEnd(c.width || 20))
+    .join("  ");
+  console.log(header);
+  console.log("-".repeat(header.length));
+
+  // Rows
+  for (const item of items) {
+    const row = columns
+      .map((c) => {
+        const val = String(item[c.key] ?? "");
+        return val.padEnd(c.width || 20).slice(0, c.width || 20);
+      })
+      .join("  ");
+    console.log(row);
+  }
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,0 +1,38 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+interface Config {
+  url: string;
+  token: string;
+}
+
+const CONFIG_DIR = join(homedir(), ".config", "tuis");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+export function loadConfig(): Config | null {
+  if (!existsSync(CONFIG_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function saveConfig(config: Config): void {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n", {
+    mode: 0o600,
+  });
+}
+
+export function requireConfig(): Config {
+  const config = loadConfig();
+  if (!config) {
+    console.error(
+      "Not configured. Run `tuis configure` to set your server URL and token."
+    );
+    process.exit(1);
+  }
+  return config;
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -20,7 +20,7 @@ export function loadConfig(): Config | null {
 }
 
 export function saveConfig(config: Config): void {
-  mkdirSync(CONFIG_DIR, { recursive: true });
+  mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n", {
     mode: 0o600,
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,897 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { loadConfig, saveConfig } from "./config.js";
+import { api, printJson, printTable } from "./api.js";
+import { createInterface } from "readline/promises";
+
+const program = new Command();
+
+program
+  .name("tuis")
+  .description("CLI for the Tuis household management app")
+  .version("1.0.0");
+
+// ─── Configure ──────────────────────────────────────────────────────────────
+
+program
+  .command("configure")
+  .description("Set server URL and access token")
+  .option("--url <url>", "Server URL")
+  .option("--token <token>", "Personal access token")
+  .action(async (opts) => {
+    const existing = loadConfig();
+    let url = opts.url;
+    let token = opts.token;
+
+    if (!url || !token) {
+      const rl = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+      });
+      if (!url) {
+        url = await rl.question(
+          `Server URL [${existing?.url || "http://localhost:3000"}]: `
+        );
+        if (!url) url = existing?.url || "http://localhost:3000";
+      }
+      if (!token) {
+        token = await rl.question("Access token: ");
+      }
+      rl.close();
+    }
+
+    saveConfig({ url, token });
+    console.log("Configuration saved.");
+  });
+
+// ─── Tasks ──────────────────────────────────────────────────────────────────
+
+const tasks = program.command("tasks").description("Manage household tasks");
+
+tasks
+  .command("list")
+  .description("List all tasks")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/tasks")) as Record<string, unknown>[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 30 },
+      { key: "area", label: "Area", width: 15 },
+      { key: "frequency", label: "Freq", width: 12 },
+      { key: "nextDue", label: "Next Due", width: 12 },
+    ]);
+  });
+
+tasks
+  .command("get <id>")
+  .description("Get a task by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/tasks/${id}`));
+  });
+
+tasks
+  .command("create")
+  .description("Create a task")
+  .requiredOption("--name <name>", "Task name")
+  .requiredOption("--area <area>", "Area (Kitchen, Bathroom, etc.)")
+  .requiredOption(
+    "--frequency <freq>",
+    "Frequency (Daily, Weekly, Monthly, etc.)"
+  )
+  .option("--assigned-day <day>", "Day of week")
+  .option("--notes <notes>", "Notes")
+  .option("--next-due <date>", "Next due date (YYYY-MM-DD)")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/tasks", {
+        method: "POST",
+        body: JSON.stringify({
+          name: opts.name,
+          area: opts.area,
+          frequency: opts.frequency,
+          assignedDay: opts.assignedDay,
+          notes: opts.notes,
+          nextDue: opts.nextDue,
+        }),
+      })
+    );
+  });
+
+tasks
+  .command("update <id>")
+  .description("Update a task")
+  .option("--name <name>", "Task name")
+  .option("--area <area>", "Area")
+  .option("--frequency <freq>", "Frequency")
+  .option("--notes <notes>", "Notes")
+  .option("--next-due <date>", "Next due date")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.name) body.name = opts.name;
+    if (opts.area) body.area = opts.area;
+    if (opts.frequency) body.frequency = opts.frequency;
+    if (opts.notes) body.notes = opts.notes;
+    if (opts.nextDue) body.nextDue = opts.nextDue;
+    printJson(
+      await api(`/api/tasks/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+tasks
+  .command("delete <id>")
+  .description("Delete a task")
+  .action(async (id) => {
+    printJson(await api(`/api/tasks/${id}`, { method: "DELETE" }));
+  });
+
+tasks
+  .command("complete <id>")
+  .description("Mark a task as complete")
+  .action(async (id) => {
+    printJson(await api(`/api/tasks/${id}/complete`, { method: "POST" }));
+  });
+
+// ─── Shopping ───────────────────────────────────────────────────────────────
+
+const shopping = program
+  .command("shopping")
+  .description("Manage shopping lists and items");
+
+const shoppingLists = shopping
+  .command("lists")
+  .description("Manage shopping lists");
+
+shoppingLists
+  .command("list")
+  .description("List all shopping lists")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/shopping/lists")) as Record<
+      string,
+      unknown
+    >[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 30 },
+    ]);
+  });
+
+shoppingLists
+  .command("create")
+  .description("Create a shopping list")
+  .requiredOption("--name <name>", "List name")
+  .option("--color <color>", "Color hex")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/shopping/lists", {
+        method: "POST",
+        body: JSON.stringify({ name: opts.name, color: opts.color }),
+      })
+    );
+  });
+
+shoppingLists
+  .command("delete <id>")
+  .description("Delete a shopping list")
+  .action(async (id) => {
+    printJson(
+      await api(`/api/shopping/lists/${id}`, { method: "DELETE" })
+    );
+  });
+
+const shoppingItems = shopping
+  .command("items")
+  .description("Manage shopping items");
+
+shoppingItems
+  .command("add")
+  .description("Add an item to a list")
+  .requiredOption("--list <id>", "List ID")
+  .requiredOption("--name <name>", "Item name")
+  .option("--quantity <qty>", "Quantity")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/shopping/items", {
+        method: "POST",
+        body: JSON.stringify({
+          listId: parseInt(opts.list),
+          name: opts.name,
+          quantity: opts.quantity,
+        }),
+      })
+    );
+  });
+
+shoppingItems
+  .command("update <id>")
+  .description("Update a shopping item")
+  .option("--name <name>", "Item name")
+  .option("--quantity <qty>", "Quantity")
+  .option("--checked", "Mark as checked")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.name) body.name = opts.name;
+    if (opts.quantity) body.quantity = opts.quantity;
+    if (opts.checked !== undefined) body.checked = true;
+    printJson(
+      await api(`/api/shopping/items/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+shoppingItems
+  .command("delete <id>")
+  .description("Delete a shopping item")
+  .action(async (id) => {
+    printJson(
+      await api(`/api/shopping/items/${id}`, { method: "DELETE" })
+    );
+  });
+
+// ─── Recipes ────────────────────────────────────────────────────────────────
+
+const recipes = program.command("recipes").description("Manage recipes");
+
+recipes
+  .command("list")
+  .description("List all recipes")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/recipes")) as Record<string, unknown>[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 30 },
+      { key: "category", label: "Category", width: 10 },
+      { key: "prepTime", label: "Prep", width: 6 },
+      { key: "cookTime", label: "Cook", width: 6 },
+    ]);
+  });
+
+recipes
+  .command("get <id>")
+  .description("Get a recipe by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/recipes/${id}`));
+  });
+
+recipes
+  .command("create")
+  .description("Create a recipe")
+  .requiredOption("--name <name>", "Recipe name")
+  .option("--description <desc>", "Description")
+  .option("--instructions <text>", "Instructions")
+  .option("--prep-time <mins>", "Prep time in minutes")
+  .option("--cook-time <mins>", "Cook time in minutes")
+  .option("--servings <n>", "Number of servings")
+  .option("--category <cat>", "Category (side, main, dessert)")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/recipes", {
+        method: "POST",
+        body: JSON.stringify({
+          name: opts.name,
+          description: opts.description,
+          instructions: opts.instructions,
+          prepTime: opts.prepTime ? parseInt(opts.prepTime) : undefined,
+          cookTime: opts.cookTime ? parseInt(opts.cookTime) : undefined,
+          servings: opts.servings ? parseInt(opts.servings) : undefined,
+          category: opts.category,
+        }),
+      })
+    );
+  });
+
+recipes
+  .command("update <id>")
+  .description("Update a recipe")
+  .option("--name <name>", "Recipe name")
+  .option("--description <desc>", "Description")
+  .option("--category <cat>", "Category")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.name) body.name = opts.name;
+    if (opts.description) body.description = opts.description;
+    if (opts.category) body.category = opts.category;
+    printJson(
+      await api(`/api/recipes/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+recipes
+  .command("delete <id>")
+  .description("Delete a recipe")
+  .action(async (id) => {
+    printJson(await api(`/api/recipes/${id}`, { method: "DELETE" }));
+  });
+
+// ─── Meals ──────────────────────────────────────────────────────────────────
+
+const meals = program.command("meals").description("Manage meal plan");
+
+meals
+  .command("list")
+  .description("List meal plan for a date range")
+  .requiredOption("--start <date>", "Start date (YYYY-MM-DD)")
+  .requiredOption("--end <date>", "End date (YYYY-MM-DD)")
+  .action(async (opts) => {
+    printJson(
+      await api(`/api/meals?start=${opts.start}&end=${opts.end}`)
+    );
+  });
+
+meals
+  .command("get <date>")
+  .description("Get meal for a specific date")
+  .action(async (date) => {
+    printJson(await api(`/api/meals/${date}`));
+  });
+
+meals
+  .command("set <date>")
+  .description("Set a meal for a date")
+  .option("--recipe <id>", "Recipe ID")
+  .option("--custom <name>", "Custom meal name")
+  .option("--slot <slot>", "Slot (side, main, dessert)", "main")
+  .option("--notes <notes>", "Notes")
+  .action(async (date, opts) => {
+    printJson(
+      await api(`/api/meals/${date}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          recipeId: opts.recipe ? parseInt(opts.recipe) : undefined,
+          customMeal: opts.custom,
+          slot: opts.slot,
+          notes: opts.notes,
+        }),
+      })
+    );
+  });
+
+meals
+  .command("delete <date>")
+  .description("Delete a meal plan entry")
+  .option("--slot <slot>", "Slot (side, main, dessert)", "main")
+  .action(async (date, opts) => {
+    printJson(
+      await api(`/api/meals/${date}?slot=${opts.slot}`, {
+        method: "DELETE",
+      })
+    );
+  });
+
+// ─── Vehicles ───────────────────────────────────────────────────────────────
+
+const vehicles = program.command("vehicles").description("Manage vehicles");
+
+vehicles
+  .command("list")
+  .description("List all vehicles")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/vehicles")) as Record<string, unknown>[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 20 },
+      { key: "make", label: "Make", width: 12 },
+      { key: "model", label: "Model", width: 12 },
+      { key: "year", label: "Year", width: 6 },
+    ]);
+  });
+
+vehicles
+  .command("get <id>")
+  .description("Get a vehicle by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/vehicles/${id}`));
+  });
+
+vehicles
+  .command("create")
+  .description("Create a vehicle")
+  .requiredOption("--name <name>", "Vehicle name")
+  .option("--make <make>", "Make")
+  .option("--model <model>", "Model")
+  .option("--year <year>", "Year")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/vehicles", {
+        method: "POST",
+        body: JSON.stringify({
+          name: opts.name,
+          make: opts.make,
+          model: opts.model,
+          year: opts.year ? parseInt(opts.year) : undefined,
+        }),
+      })
+    );
+  });
+
+vehicles
+  .command("update <id>")
+  .description("Update a vehicle")
+  .option("--name <name>", "Name")
+  .option("--make <make>", "Make")
+  .option("--model <model>", "Model")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.name) body.name = opts.name;
+    if (opts.make) body.make = opts.make;
+    if (opts.model) body.model = opts.model;
+    printJson(
+      await api(`/api/vehicles/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+vehicles
+  .command("delete <id>")
+  .description("Delete a vehicle")
+  .action(async (id) => {
+    printJson(await api(`/api/vehicles/${id}`, { method: "DELETE" }));
+  });
+
+const fuel = vehicles.command("fuel").description("Manage fuel logs");
+
+fuel
+  .command("list <vehicleId>")
+  .description("List fuel logs for a vehicle")
+  .action(async (vehicleId) => {
+    printJson(await api(`/api/vehicles/${vehicleId}/fuel`));
+  });
+
+fuel
+  .command("add <vehicleId>")
+  .description("Add a fuel log")
+  .requiredOption("--date <date>", "Date (YYYY-MM-DD)")
+  .requiredOption("--odometer <km>", "Odometer reading")
+  .requiredOption("--litres <l>", "Litres")
+  .requiredOption("--cost <amount>", "Total cost")
+  .option("--station <name>", "Station")
+  .action(async (vehicleId, opts) => {
+    printJson(
+      await api(`/api/vehicles/${vehicleId}/fuel`, {
+        method: "POST",
+        body: JSON.stringify({
+          date: opts.date,
+          odometer: parseInt(opts.odometer),
+          litres: parseFloat(opts.litres),
+          costTotal: parseFloat(opts.cost),
+          station: opts.station,
+        }),
+      })
+    );
+  });
+
+const services = vehicles
+  .command("services")
+  .description("Manage vehicle services");
+
+services
+  .command("list <vehicleId>")
+  .description("List services for a vehicle")
+  .action(async (vehicleId) => {
+    printJson(await api(`/api/vehicles/${vehicleId}/services`));
+  });
+
+services
+  .command("add <vehicleId>")
+  .description("Add a service record")
+  .requiredOption("--date <date>", "Date (YYYY-MM-DD)")
+  .requiredOption("--description <desc>", "Description")
+  .option("--odometer <km>", "Odometer reading")
+  .option("--cost <amount>", "Cost")
+  .option("--service-type <type>", "Service type")
+  .action(async (vehicleId, opts) => {
+    printJson(
+      await api(`/api/vehicles/${vehicleId}/services`, {
+        method: "POST",
+        body: JSON.stringify({
+          date: opts.date,
+          description: opts.description,
+          odometer: opts.odometer ? parseInt(opts.odometer) : undefined,
+          cost: opts.cost ? parseFloat(opts.cost) : undefined,
+          serviceType: opts.serviceType,
+        }),
+      })
+    );
+  });
+
+// ─── Vendors ────────────────────────────────────────────────────────────────
+
+const vendors = program.command("vendors").description("Manage vendors");
+
+vendors
+  .command("list")
+  .description("List all vendors")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/vendors")) as Record<string, unknown>[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 25 },
+      { key: "category", label: "Category", width: 15 },
+      { key: "phone", label: "Phone", width: 15 },
+      { key: "rating", label: "Rating", width: 6 },
+    ]);
+  });
+
+vendors
+  .command("get <id>")
+  .description("Get a vendor by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/vendors/${id}`));
+  });
+
+vendors
+  .command("create")
+  .description("Create a vendor")
+  .requiredOption("--name <name>", "Vendor name")
+  .option("--category <cat>", "Category")
+  .option("--phone <phone>", "Phone number")
+  .option("--email <email>", "Email")
+  .option("--rating <n>", "Rating (1-5)")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/vendors", {
+        method: "POST",
+        body: JSON.stringify({
+          name: opts.name,
+          category: opts.category,
+          phone: opts.phone,
+          email: opts.email,
+          rating: opts.rating ? parseInt(opts.rating) : undefined,
+        }),
+      })
+    );
+  });
+
+vendors
+  .command("update <id>")
+  .description("Update a vendor")
+  .option("--name <name>", "Name")
+  .option("--category <cat>", "Category")
+  .option("--phone <phone>", "Phone")
+  .option("--email <email>", "Email")
+  .option("--rating <n>", "Rating")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.name) body.name = opts.name;
+    if (opts.category) body.category = opts.category;
+    if (opts.phone) body.phone = opts.phone;
+    if (opts.email) body.email = opts.email;
+    if (opts.rating) body.rating = parseInt(opts.rating);
+    printJson(
+      await api(`/api/vendors/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+vendors
+  .command("delete <id>")
+  .description("Delete a vendor")
+  .action(async (id) => {
+    printJson(await api(`/api/vendors/${id}`, { method: "DELETE" }));
+  });
+
+// ─── Quotes ─────────────────────────────────────────────────────────────────
+
+const quotes = program.command("quotes").description("Manage quotes");
+
+quotes
+  .command("list")
+  .description("List all quotes")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/quotes")) as Record<string, unknown>[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "description", label: "Description", width: 30 },
+      { key: "total", label: "Total", width: 10 },
+      { key: "status", label: "Status", width: 10 },
+    ]);
+  });
+
+quotes
+  .command("get <id>")
+  .description("Get a quote by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/quotes/${id}`));
+  });
+
+quotes
+  .command("create")
+  .description("Create a quote")
+  .requiredOption("--description <desc>", "Description")
+  .requiredOption("--total <amount>", "Total amount")
+  .option("--vendor <id>", "Vendor ID")
+  .option("--status <status>", "Status (pending, accepted, rejected)")
+  .option("--labour <amount>", "Labour cost")
+  .option("--materials <amount>", "Materials cost")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/quotes", {
+        method: "POST",
+        body: JSON.stringify({
+          description: opts.description,
+          total: parseFloat(opts.total),
+          vendorId: opts.vendor ? parseInt(opts.vendor) : undefined,
+          status: opts.status,
+          labour: opts.labour ? parseFloat(opts.labour) : undefined,
+          materials: opts.materials
+            ? parseFloat(opts.materials)
+            : undefined,
+        }),
+      })
+    );
+  });
+
+quotes
+  .command("update <id>")
+  .description("Update a quote")
+  .option("--description <desc>", "Description")
+  .option("--total <amount>", "Total")
+  .option("--status <status>", "Status")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.description) body.description = opts.description;
+    if (opts.total) body.total = parseFloat(opts.total);
+    if (opts.status) body.status = opts.status;
+    printJson(
+      await api(`/api/quotes/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+quotes
+  .command("delete <id>")
+  .description("Delete a quote")
+  .action(async (id) => {
+    printJson(await api(`/api/quotes/${id}`, { method: "DELETE" }));
+  });
+
+// ─── Appliances ─────────────────────────────────────────────────────────────
+
+const appliances = program
+  .command("appliances")
+  .description("Manage appliances");
+
+appliances
+  .command("list")
+  .description("List all appliances")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/appliances")) as Record<
+      string,
+      unknown
+    >[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 25 },
+      { key: "brand", label: "Brand", width: 15 },
+      { key: "location", label: "Location", width: 15 },
+    ]);
+  });
+
+appliances
+  .command("get <id>")
+  .description("Get an appliance by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/appliances/${id}`));
+  });
+
+appliances
+  .command("create")
+  .description("Create an appliance")
+  .requiredOption("--name <name>", "Appliance name")
+  .option("--brand <brand>", "Brand")
+  .option("--model <model>", "Model")
+  .option("--location <loc>", "Location")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/appliances", {
+        method: "POST",
+        body: JSON.stringify({
+          name: opts.name,
+          brand: opts.brand,
+          model: opts.model,
+          location: opts.location,
+        }),
+      })
+    );
+  });
+
+appliances
+  .command("update <id>")
+  .description("Update an appliance")
+  .option("--name <name>", "Name")
+  .option("--brand <brand>", "Brand")
+  .option("--model <model>", "Model")
+  .option("--location <loc>", "Location")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.name) body.name = opts.name;
+    if (opts.brand) body.brand = opts.brand;
+    if (opts.model) body.model = opts.model;
+    if (opts.location) body.location = opts.location;
+    printJson(
+      await api(`/api/appliances/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+appliances
+  .command("delete <id>")
+  .description("Delete an appliance")
+  .action(async (id) => {
+    printJson(await api(`/api/appliances/${id}`, { method: "DELETE" }));
+  });
+
+// ─── Activities (Together) ──────────────────────────────────────────────────
+
+const activities = program
+  .command("activities")
+  .description("Manage together activities");
+
+activities
+  .command("list")
+  .description("List all activities")
+  .option("--json", "Output as JSON")
+  .option("--status <status>", "Filter by status")
+  .option("--category <cat>", "Filter by category")
+  .action(async (opts) => {
+    const params = new URLSearchParams();
+    if (opts.status) params.set("status", opts.status);
+    if (opts.category) params.set("category", opts.category);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    const data = (await api(`/api/together${qs}`)) as Record<
+      string,
+      unknown
+    >[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "title", label: "Title", width: 30 },
+      { key: "category", label: "Category", width: 12 },
+      { key: "status", label: "Status", width: 10 },
+    ]);
+  });
+
+activities
+  .command("get <id>")
+  .description("Get an activity by ID")
+  .action(async (id) => {
+    printJson(await api(`/api/together/${id}`));
+  });
+
+activities
+  .command("create")
+  .description("Create an activity")
+  .requiredOption("--title <title>", "Activity title")
+  .requiredOption(
+    "--category <cat>",
+    "Category (location, activity, restaurant, dish, film)"
+  )
+  .option("--status <status>", "Status (wishlist, planned, completed)")
+  .option("--notes <notes>", "Notes")
+  .option("--url <url>", "URL")
+  .option("--location <loc>", "Location")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/together", {
+        method: "POST",
+        body: JSON.stringify({
+          title: opts.title,
+          category: opts.category,
+          status: opts.status,
+          notes: opts.notes,
+          url: opts.url,
+          location: opts.location,
+        }),
+      })
+    );
+  });
+
+activities
+  .command("update <id>")
+  .description("Update an activity")
+  .option("--title <title>", "Title")
+  .option("--status <status>", "Status")
+  .option("--notes <notes>", "Notes")
+  .option("--rating <n>", "Rating (1-5)")
+  .action(async (id, opts) => {
+    const body: Record<string, unknown> = {};
+    if (opts.title) body.title = opts.title;
+    if (opts.status) body.status = opts.status;
+    if (opts.notes) body.notes = opts.notes;
+    if (opts.rating) body.rating = parseInt(opts.rating);
+    printJson(
+      await api(`/api/together/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+      })
+    );
+  });
+
+activities
+  .command("delete <id>")
+  .description("Delete an activity")
+  .action(async (id) => {
+    printJson(await api(`/api/together/${id}`, { method: "DELETE" }));
+  });
+
+// ─── Users ──────────────────────────────────────────────────────────────────
+
+const users = program
+  .command("users")
+  .description("Manage household members");
+
+users
+  .command("list")
+  .description("List all household members")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const data = (await api("/api/users")) as Record<string, unknown>[];
+    if (opts.json) return printJson(data);
+    printTable(data, [
+      { key: "id", label: "ID", width: 5 },
+      { key: "name", label: "Name", width: 25 },
+      { key: "color", label: "Color", width: 10 },
+    ]);
+  });
+
+users
+  .command("create")
+  .description("Create a household member")
+  .requiredOption("--name <name>", "Name")
+  .option("--color <color>", "Color hex")
+  .action(async (opts) => {
+    printJson(
+      await api("/api/users", {
+        method: "POST",
+        body: JSON.stringify({ name: opts.name, color: opts.color }),
+      })
+    );
+  });
+
+users
+  .command("delete <id>")
+  .description("Delete a household member")
+  .action(async (id) => {
+    printJson(await api(`/api/users/${id}`, { method: "DELETE" }));
+  });
+
+// ─── Stats ──────────────────────────────────────────────────────────────────
+
+program
+  .command("stats")
+  .description("View household stats")
+  .action(async () => {
+    printJson(await api("/api/stats"));
+  });
+
+program.parse();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -215,11 +215,12 @@ shoppingItems
   .option("--name <name>", "Item name")
   .option("--quantity <qty>", "Quantity")
   .option("--checked", "Mark as checked")
+  .option("--no-checked", "Mark as unchecked")
   .action(async (id, opts) => {
     const body: Record<string, unknown> = {};
-    if (opts.name) body.name = opts.name;
-    if (opts.quantity) body.quantity = opts.quantity;
-    if (opts.checked !== undefined) body.checked = true;
+    if (opts.name !== undefined) body.name = opts.name;
+    if (opts.quantity !== undefined) body.quantity = opts.quantity;
+    if (opts.checked !== undefined) body.checked = opts.checked;
     printJson(
       await api(`/api/shopping/items/${id}`, {
         method: "PUT",

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/e2e/tokens.spec.ts
+++ b/e2e/tokens.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page } from "@playwright/test";
+import { cleanupTestData } from "./cleanup";
+
+const TOKEN_NAME = `E2E Test Token ${Date.now()}`;
+
+async function dismissUserPickerIfVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  const dialog = page.getByRole("dialog");
+  const isVisible = await dialog.isVisible().catch(() => false);
+  if (isVisible) {
+    const heading = dialog.getByRole("heading");
+    const text = await heading.textContent().catch(() => "");
+    if (text === "Who are you?" || text === "Switch User") {
+      const userButton = dialog.locator("button").first();
+      if (await userButton.isVisible().catch(() => false)) {
+        await userButton.click();
+        await expect(dialog).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+  }
+}
+
+test.afterAll(async ({ request }) => {
+  await cleanupTestData(request, "tokens", "E2E Test Token%");
+});
+
+test.describe.serial("Personal Access Tokens", () => {
+  test("should show empty token list on settings page", async ({ page }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Personal Access Tokens" })
+    ).toBeVisible();
+    await expect(
+      page.getByText("No tokens yet. Create one to use with the CLI.")
+    ).toBeVisible();
+  });
+
+  test("should create a token with selected scopes", async ({ page }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    // Open create dialog
+    await page.getByRole("button", { name: "Create Token" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Create Access Token" })
+    ).toBeVisible();
+
+    // Fill name
+    await page.getByLabel("Token Name").fill(TOKEN_NAME);
+
+    // Select scopes - click "Tasks" group label to select both read+write
+    await page.getByRole("button", { name: "Tasks" }).click();
+
+    // Create
+    await page.getByRole("button", { name: "Create" }).click();
+
+    // Should show the token once
+    await expect(
+      page.getByRole("heading", { name: "Token Created" })
+    ).toBeVisible();
+    await expect(
+      page.getByText("Copy this token now. It will not be shown again.")
+    ).toBeVisible();
+
+    // Token should be visible in the input
+    const tokenInput = page.locator('input[readonly]');
+    const tokenValue = await tokenInput.inputValue();
+    expect(tokenValue).toMatch(/^tuis_[a-f0-9]{64}$/);
+
+    // Close dialog
+    await page.getByRole("button", { name: "Done" }).click();
+
+    // Token should appear in the list
+    await expect(page.getByText(TOKEN_NAME)).toBeVisible();
+  });
+
+  test("should delete a token", async ({ page }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    // The token from the previous test should be visible
+    await expect(page.getByText(TOKEN_NAME)).toBeVisible();
+
+    // Click delete - handle confirm dialog
+    page.on("dialog", (dialog) => dialog.accept());
+    // Find the delete button in the row containing our token name
+    const container = page.getByText(TOKEN_NAME).locator("../..");
+    await container.getByRole("button").click();
+
+    // Token should disappear
+    await expect(page.getByText(TOKEN_NAME)).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test("should enforce auth via API with valid token", async ({ request }) => {
+    // Create a token via API
+    const createRes = await request.post("/api/tokens", {
+      data: {
+        name: `E2E Test Token API ${Date.now()}`,
+        scopes: ["tasks:read"],
+      },
+    });
+    expect(createRes.status()).toBe(201);
+    const { token, id } = await createRes.json();
+
+    // Use the token to access tasks
+    const tasksRes = await request.get("/api/tasks", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(tasksRes.status()).toBe(200);
+
+    // Invalid token should fail
+    const badRes = await request.get("/api/tasks", {
+      headers: { Authorization: "Bearer tuis_invalid" },
+    });
+    expect(badRes.status()).toBe(401);
+
+    // Wrong scope should fail
+    const wrongScopeRes = await request.post("/api/tasks", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      data: { name: "Test", area: "Kitchen", frequency: "Weekly" },
+    });
+    expect(wrongScopeRes.status()).toBe(403);
+
+    // Clean up
+    await request.delete(`/api/tokens/${id}`);
+  });
+});

--- a/src/app/api/__tests__/quotes.test.ts
+++ b/src/app/api/__tests__/quotes.test.ts
@@ -558,7 +558,7 @@ describe("Recent Completions API", () => {
 
   describe("GET /api/stats/recent-completions", () => {
     it("returns empty array when no completions exist", async () => {
-      const res = await recentRoute.GET();
+      const res = await recentRoute.GET(makeRequest("/api/stats/recent-completions"));
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual([]);
     });
@@ -577,7 +577,7 @@ describe("Recent Completions API", () => {
 
       insertCompletion(taskId, today, { completed_by: userId });
 
-      const res = await recentRoute.GET();
+      const res = await recentRoute.GET(makeRequest("/api/stats/recent-completions"));
       const data = await res.json();
 
       expect(data).toHaveLength(1);
@@ -599,7 +599,7 @@ describe("Recent Completions API", () => {
       // Insert completion well before this week
       insertCompletion(taskId, "2020-01-01");
 
-      const res = await recentRoute.GET();
+      const res = await recentRoute.GET(makeRequest("/api/stats/recent-completions"));
       const data = await res.json();
 
       expect(data).toEqual([]);
@@ -623,7 +623,7 @@ describe("Recent Completions API", () => {
       insertCompletion(Number(task1.lastInsertRowid), weekStart);
       insertCompletion(Number(task2.lastInsertRowid), laterDate);
 
-      const res = await recentRoute.GET();
+      const res = await recentRoute.GET(makeRequest("/api/stats/recent-completions"));
       const data = await res.json();
 
       expect(data).toHaveLength(2);
@@ -639,7 +639,7 @@ describe("Recent Completions API", () => {
 
       insertCompletion(taskId, today);
 
-      const res = await recentRoute.GET();
+      const res = await recentRoute.GET(makeRequest("/api/stats/recent-completions"));
       const data = await res.json();
 
       expect(data).toHaveLength(1);
@@ -656,7 +656,7 @@ describe("Recent Completions API", () => {
         insertCompletion(taskId, today);
       }
 
-      const res = await recentRoute.GET();
+      const res = await recentRoute.GET(makeRequest("/api/stats/recent-completions"));
       const data = await res.json();
 
       expect(data).toHaveLength(30);

--- a/src/app/api/__tests__/tokens.test.ts
+++ b/src/app/api/__tests__/tokens.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+// ─── In-memory DB wiring ────────────────────────────────────────────────────
+
+let testDb: ReturnType<typeof drizzle>;
+let sqlite: Database.Database;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+  schema,
+}));
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL DEFAULT '#3b82f6',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      area TEXT NOT NULL,
+      frequency TEXT NOT NULL,
+      assigned_day TEXT,
+      season TEXT,
+      notes TEXT,
+      extended_notes TEXT,
+      assigned_to INTEGER REFERENCES users(id),
+      appliance_id INTEGER,
+      last_completed TEXT,
+      next_due TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS personal_access_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      scopes TEXT NOT NULL,
+      last_used_at TEXT,
+      expires_at TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${url}`, init);
+}
+
+function jsonBody(data: Record<string, unknown>): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TOKEN CRUD API
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Token API", () => {
+  let tokenRoute: typeof import("@/app/api/tokens/route");
+  let tokenIdRoute: typeof import("@/app/api/tokens/[id]/route");
+
+  beforeEach(async () => {
+    tokenRoute = await import("@/app/api/tokens/route");
+    tokenIdRoute = await import("@/app/api/tokens/[id]/route");
+  });
+
+  describe("POST /api/tokens", () => {
+    it("creates a token and returns it once", async () => {
+      const req = makeRequest(
+        "/api/tokens",
+        jsonBody({ name: "CLI", scopes: ["tasks:read", "tasks:write"] })
+      );
+      const res = await tokenRoute.POST(req);
+      expect(res.status).toBe(201);
+
+      const data = await res.json();
+      expect(data.name).toBe("CLI");
+      expect(data.token).toMatch(/^tuis_[a-f0-9]{64}$/);
+      expect(data.scopes).toEqual(["tasks:read", "tasks:write"]);
+      expect(data.id).toBeDefined();
+    });
+
+    it("rejects missing name", async () => {
+      const req = makeRequest(
+        "/api/tokens",
+        jsonBody({ scopes: ["tasks:read"] })
+      );
+      const res = await tokenRoute.POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects empty scopes", async () => {
+      const req = makeRequest(
+        "/api/tokens",
+        jsonBody({ name: "Test", scopes: [] })
+      );
+      const res = await tokenRoute.POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid scopes", async () => {
+      const req = makeRequest(
+        "/api/tokens",
+        jsonBody({ name: "Test", scopes: ["invalid:scope"] })
+      );
+      const res = await tokenRoute.POST(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("invalid:scope");
+    });
+  });
+
+  describe("GET /api/tokens", () => {
+    it("returns empty array when no tokens", async () => {
+      const res = await tokenRoute.GET();
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([]);
+    });
+
+    it("lists tokens without exposing hashes", async () => {
+      // Create a token first
+      const createReq = makeRequest(
+        "/api/tokens",
+        jsonBody({ name: "CLI", scopes: ["tasks:read"] })
+      );
+      await tokenRoute.POST(createReq);
+
+      const res = await tokenRoute.GET();
+      expect(res.status).toBe(200);
+      const tokens = await res.json();
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0].name).toBe("CLI");
+      expect(tokens[0].tokenHash).toBeUndefined();
+      expect(tokens[0].token).toBeUndefined();
+    });
+  });
+
+  describe("DELETE /api/tokens/:id", () => {
+    it("deletes an existing token", async () => {
+      const createReq = makeRequest(
+        "/api/tokens",
+        jsonBody({ name: "CLI", scopes: ["tasks:read"] })
+      );
+      const createRes = await tokenRoute.POST(createReq);
+      const { id } = await createRes.json();
+
+      const deleteReq = makeRequest(`/api/tokens/${id}`, {
+        method: "DELETE",
+      });
+      const res = await tokenIdRoute.DELETE(deleteReq, {
+        params: Promise.resolve({ id: String(id) }),
+      });
+      expect(res.status).toBe(200);
+
+      // Verify it's gone
+      const listRes = await tokenRoute.GET();
+      expect(await listRes.json()).toEqual([]);
+    });
+
+    it("returns 404 for non-existent token", async () => {
+      const req = makeRequest("/api/tokens/999", { method: "DELETE" });
+      const res = await tokenIdRoute.DELETE(req, {
+        params: Promise.resolve({ id: "999" }),
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AUTH VALIDATION
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Auth Validation", () => {
+  let taskRoute: typeof import("@/app/api/tasks/route");
+  let tokenRoute: typeof import("@/app/api/tokens/route");
+
+  beforeEach(async () => {
+    taskRoute = await import("@/app/api/tasks/route");
+    tokenRoute = await import("@/app/api/tokens/route");
+  });
+
+  it("allows requests without Authorization header (web UI)", async () => {
+    const req = makeRequest("/api/tasks");
+    const res = await taskRoute.GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("allows requests with valid token and correct scope", async () => {
+    // Create a token with tasks:read scope
+    const createReq = makeRequest(
+      "/api/tokens",
+      jsonBody({ name: "Test", scopes: ["tasks:read"] })
+    );
+    const createRes = await tokenRoute.POST(createReq);
+    const { token } = await createRes.json();
+
+    const req = new Request("http://localhost/api/tasks", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const res = await taskRoute.GET(req);
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects invalid token with 401", async () => {
+    const req = new Request("http://localhost/api/tasks", {
+      headers: { Authorization: "Bearer tuis_invalidtoken123" },
+    });
+    const res = await taskRoute.GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-Bearer auth with 401", async () => {
+    const req = new Request("http://localhost/api/tasks", {
+      headers: { Authorization: "Basic abc123" },
+    });
+    const res = await taskRoute.GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects token without required scope with 403", async () => {
+    // Create a token with only shopping:read scope
+    const createReq = makeRequest(
+      "/api/tokens",
+      jsonBody({ name: "Limited", scopes: ["shopping:read"] })
+    );
+    const createRes = await tokenRoute.POST(createReq);
+    const { token } = await createRes.json();
+
+    // Try to access tasks (needs tasks:read)
+    const req = new Request("http://localhost/api/tasks", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const res = await taskRoute.GET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects expired token with 401", async () => {
+    // Create a token with past expiry
+    const createReq = makeRequest(
+      "/api/tokens",
+      jsonBody({
+        name: "Expired",
+        scopes: ["tasks:read"],
+        expiresAt: "2020-01-01T00:00:00Z",
+      })
+    );
+    const createRes = await tokenRoute.POST(createReq);
+    const { token } = await createRes.json();
+
+    const req = new Request("http://localhost/api/tasks", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const res = await taskRoute.GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("enforces write scope for POST requests", async () => {
+    // Create a token with only tasks:read
+    const createReq = makeRequest(
+      "/api/tokens",
+      jsonBody({ name: "ReadOnly", scopes: ["tasks:read"] })
+    );
+    const createRes = await tokenRoute.POST(createReq);
+    const { token } = await createRes.json();
+
+    const req = new Request("http://localhost/api/tasks", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "Test",
+        area: "Kitchen",
+        frequency: "Weekly",
+      }),
+    });
+    const res = await taskRoute.POST(req);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/appliances/[id]/route.ts
+++ b/src/app/api/appliances/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { appliances, tasks, completions } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const applianceId = parseInt(id);
 
@@ -80,6 +84,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const applianceId = parseInt(id);
     const body = await request.json();
@@ -134,6 +141,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const applianceId = parseInt(id);
 

--- a/src/app/api/appliances/route.ts
+++ b/src/app/api/appliances/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { appliances } from "@/lib/db/schema";
 import { eq, like, or, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const search = searchParams.get("search");
     const location = searchParams.get("location");
@@ -49,6 +53,9 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const {
       name,

--- a/src/app/api/e2e-cleanup/route.ts
+++ b/src/app/api/e2e-cleanup/route.ts
@@ -13,6 +13,7 @@ import {
   recipeIngredients,
   mealPlan,
   users,
+  personalAccessTokens,
 } from "@/lib/db/schema";
 import { like, eq, inArray, sql } from "drizzle-orm";
 
@@ -28,6 +29,7 @@ const VALID_TYPES = [
   "recipes",
   "meals",
   "users",
+  "tokens",
 ] as const;
 
 type CleanupType = (typeof VALID_TYPES)[number];
@@ -182,6 +184,14 @@ export async function POST(request: NextRequest) {
         const result = await db
           .delete(mealPlan)
           .where(like(mealPlan.customMeal, namePattern));
+        deleted = result.changes ?? 0;
+        break;
+      }
+
+      case "tokens": {
+        const result = await db
+          .delete(personalAccessTokens)
+          .where(like(personalAccessTokens.name, namePattern));
         deleted = result.changes ?? 0;
         break;
       }

--- a/src/app/api/meals/[date]/route.ts
+++ b/src/app/api/meals/[date]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { mealPlan, recipes, recipeIngredients } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ date: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { date } = await params;
 
     const meals = await db
@@ -60,6 +64,9 @@ export async function PUT(
   { params }: { params: Promise<{ date: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { date } = await params;
     const body = await request.json();
     const { recipeId, customMeal, notes, servingsMultiplier, slot = "main" } = body;
@@ -107,6 +114,9 @@ export async function DELETE(
   { params }: { params: Promise<{ date: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { date } = await params;
     const { searchParams } = new URL(request.url);
     const slot = searchParams.get("slot");

--- a/src/app/api/meals/ingredients/route.ts
+++ b/src/app/api/meals/ingredients/route.ts
@@ -3,11 +3,15 @@ import { db } from "@/lib/db";
 import { mealPlan, recipeIngredients, shoppingItems } from "@/lib/db/schema";
 import { eq, and, gte, lte, inArray } from "drizzle-orm";
 import { aggregateIngredients, IngredientUnit } from "@/lib/ingredients";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const start = searchParams.get("start");
     const end = searchParams.get("end");

--- a/src/app/api/meals/route.ts
+++ b/src/app/api/meals/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { mealPlan, recipes } from "@/lib/db/schema";
 import { eq, and, gte, lte } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const start = searchParams.get("start");
     const end = searchParams.get("end");

--- a/src/app/api/quotes/[id]/route.ts
+++ b/src/app/api/quotes/[id]/route.ts
@@ -2,12 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { quotes, vendors } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const quoteId = parseInt(id);
 
@@ -49,6 +53,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const quoteId = parseInt(id);
     const body = await request.json();
@@ -78,6 +85,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const quoteId = parseInt(id);
 

--- a/src/app/api/quotes/budget/route.ts
+++ b/src/app/api/quotes/budget/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 const ACTUAL_API_URL = process.env.ACTUAL_API_URL || "http://localhost:3100";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const response = await fetch(`${ACTUAL_API_URL}/api/budget/summary`, {
       next: { revalidate: 300 }, // Cache for 5 minutes
       signal: AbortSignal.timeout(5000),

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { quotes, vendors } from "@/lib/db/schema";
 import { eq, desc, sql } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const status = searchParams.get("status");
 
@@ -46,6 +50,9 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { description, vendorId, total, labour, materials, other, status, receivedDate, notes } = body;
 

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { recipes, recipeIngredients } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { formatIngredient, IngredientUnit } from "@/lib/ingredients";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +12,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const recipeId = parseInt(id);
 
@@ -45,6 +49,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const recipeId = parseInt(id);
     const body = await request.json();
@@ -114,6 +121,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const recipeId = parseInt(id);
 

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -3,11 +3,15 @@ import { db } from "@/lib/db";
 import { recipes, recipeIngredients } from "@/lib/db/schema";
 import { desc, like } from "drizzle-orm";
 import { formatIngredient, IngredientUnit } from "@/lib/ingredients";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q");
 
@@ -37,6 +41,9 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { name, description, instructions, prepTime, cookTime, servings, imageUrl, category, ingredients } = body;
 

--- a/src/app/api/shopping/items/[id]/route.ts
+++ b/src/app/api/shopping/items/[id]/route.ts
@@ -2,12 +2,16 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { shoppingItems } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export async function PUT(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const body = await request.json();
 
@@ -35,6 +39,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
 
     const result = await db

--- a/src/app/api/shopping/items/clear/route.ts
+++ b/src/app/api/shopping/items/clear/route.ts
@@ -2,9 +2,13 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { shoppingItems } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { listId } = body;
 

--- a/src/app/api/shopping/items/route.ts
+++ b/src/app/api/shopping/items/route.ts
@@ -2,9 +2,13 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { shoppingItems, itemHistory } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { listId, name, quantity, addedBy } = body;
 

--- a/src/app/api/shopping/lists/[id]/route.ts
+++ b/src/app/api/shopping/lists/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { shoppingLists, shoppingItems } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const listId = parseInt(id);
 
@@ -44,6 +48,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const body = await request.json();
 
@@ -74,6 +81,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const listId = parseInt(id);
 

--- a/src/app/api/shopping/lists/route.ts
+++ b/src/app/api/shopping/lists/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { shoppingLists, shoppingItems } from "@/lib/db/schema";
 import { desc, eq, sql } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     // Get all lists with item counts
     const lists = await db
       .select({
@@ -36,6 +40,9 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { name, color } = body;
 

--- a/src/app/api/shopping/suggestions/route.ts
+++ b/src/app/api/shopping/suggestions/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { itemHistory } from "@/lib/db/schema";
 import { like, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q") || "";
 

--- a/src/app/api/stats/recent-completions/route.ts
+++ b/src/app/api/stats/recent-completions/route.ts
@@ -3,11 +3,15 @@ import { db } from "@/lib/db";
 import { completions, tasks, users } from "@/lib/db/schema";
 import { eq, gte, desc } from "drizzle-orm";
 import { subDays, format, startOfWeek } from "date-fns";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const weekStart = format(
       startOfWeek(new Date(), { weekStartsOn: 1 }),
       "yyyy-MM-dd"

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -3,11 +3,15 @@ import { db } from "@/lib/db";
 import { tasks, completions } from "@/lib/db/schema";
 import { sql, eq, gte, and, count } from "drizzle-orm";
 import { subDays, startOfDay, startOfWeek, startOfMonth, format } from "date-fns";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const now = new Date();
     const todayStart = format(startOfDay(now), "yyyy-MM-dd");
     const weekStart = format(startOfWeek(now, { weekStartsOn: 1 }), "yyyy-MM-dd");

--- a/src/app/api/tasks/[id]/complete/route.ts
+++ b/src/app/api/tasks/[id]/complete/route.ts
@@ -10,6 +10,7 @@ import {
   parseISO,
 } from "date-fns";
 import { syncTask } from "@/lib/calendar";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 function calculateNextDue(frequency: string, completedDate: Date): string | null {
   const freq = frequency.toLowerCase();
@@ -45,6 +46,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const body = await request.json();
     const completedDateStr = body.completedDate || format(new Date(), "yyyy-MM-dd");

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { tasks, completions } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { syncTask, deleteTaskCalendarEvents } from "@/lib/calendar";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +12,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const task = await db.select().from(tasks).where(eq(tasks.id, parseInt(id))).limit(1);
 
@@ -30,6 +34,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const body = await request.json();
 
@@ -67,6 +74,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const taskId = parseInt(id);
 

--- a/src/app/api/tasks/[id]/snooze/route.ts
+++ b/src/app/api/tasks/[id]/snooze/route.ts
@@ -4,12 +4,16 @@ import { tasks } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { addDays, addWeeks, format, parseISO } from "date-fns";
 import { syncTask } from "@/lib/calendar";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const body = await request.json();
     const { duration } = body; // "1day", "3days", "1week", "2weeks"

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,11 +3,15 @@ import { db } from "@/lib/db";
 import { tasks } from "@/lib/db/schema";
 import { desc, eq } from "drizzle-orm";
 import { syncTask } from "@/lib/calendar";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const allTasks = await db.select().from(tasks).orderBy(desc(tasks.nextDue));
     return NextResponse.json(allTasks);
   } catch (error) {
@@ -18,6 +22,9 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { name, area, frequency, assignedDay, season, notes, nextDue, applianceId } = body;
 

--- a/src/app/api/together/[id]/route.ts
+++ b/src/app/api/together/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { activities } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const activityId = parseInt(id);
 
@@ -38,6 +42,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const activityId = parseInt(id);
     const body = await request.json();
@@ -100,6 +107,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const activityId = parseInt(id);
 

--- a/src/app/api/together/export/route.ts
+++ b/src/app/api/together/export/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { activities } from "@/lib/db/schema";
 import { desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -50,6 +51,9 @@ const PRIORITY_LABELS: Record<string, string> = {
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const format = searchParams.get("format") || "json";
 

--- a/src/app/api/together/import/route.ts
+++ b/src/app/api/together/import/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { activities } from "@/lib/db/schema";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 const VALID_CATEGORIES = ["location", "activity", "restaurant", "dish", "film"];
 const VALID_STATUSES = ["wishlist", "planned", "completed"];
@@ -87,6 +88,9 @@ function validateActivity(item: ImportActivity, index: number): string[] {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
 
     // Validate structure

--- a/src/app/api/together/route.ts
+++ b/src/app/api/together/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { activities } from "@/lib/db/schema";
 import { desc, eq, and, like } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const status = searchParams.get("status");
     const category = searchParams.get("category");
@@ -50,6 +54,9 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const {
       title,

--- a/src/app/api/tokens/[id]/route.ts
+++ b/src/app/api/tokens/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export const dynamic = "force-dynamic";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await db
+      .delete(personalAccessTokens)
+      .where(eq(personalAccessTokens.id, parseInt(id)));
+
+    if (result.changes === 0) {
+      return NextResponse.json({ error: "Token not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting token:", error);
+    return NextResponse.json(
+      { error: "Failed to delete token" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { hashToken } from "@/lib/auth/validate";
+import { ALL_SCOPES } from "@/lib/auth/scopes";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const tokens = await db.select().from(personalAccessTokens);
+    // Never return the hash
+    return NextResponse.json(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      tokens.map(({ tokenHash: _hash, ...rest }) => rest)
+    );
+  } catch (error) {
+    console.error("Error fetching tokens:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch tokens" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { name, scopes, expiresAt } = body;
+
+    if (!name || typeof name !== "string") {
+      return NextResponse.json(
+        { error: "Name is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!Array.isArray(scopes) || scopes.length === 0) {
+      return NextResponse.json(
+        { error: "At least one scope is required" },
+        { status: 400 }
+      );
+    }
+
+    // Validate scopes
+    const invalidScopes = scopes.filter((s: string) => !ALL_SCOPES.includes(s));
+    if (invalidScopes.length > 0) {
+      return NextResponse.json(
+        { error: `Invalid scopes: ${invalidScopes.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    const rawToken = `tuis_${randomBytes(32).toString("hex")}`;
+    const tokenHash = hashToken(rawToken);
+
+    const result = await db.insert(personalAccessTokens).values({
+      name,
+      tokenHash,
+      scopes: JSON.stringify(scopes),
+      expiresAt: expiresAt || null,
+    });
+
+    return NextResponse.json(
+      {
+        id: Number(result.lastInsertRowid),
+        name,
+        token: rawToken, // Only returned once
+        scopes,
+        expiresAt: expiresAt || null,
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error creating token:", error);
+    return NextResponse.json(
+      { error: "Failed to create token" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tokens/route.ts
+++ b/src/app/api/tokens/route.ts
@@ -52,6 +52,19 @@ export async function POST(request: Request) {
       );
     }
 
+    // Validate expiresAt if provided
+    let validatedExpiry: string | null = null;
+    if (expiresAt) {
+      const d = new Date(expiresAt);
+      if (isNaN(d.getTime())) {
+        return NextResponse.json(
+          { error: "Invalid expiresAt date" },
+          { status: 400 }
+        );
+      }
+      validatedExpiry = d.toISOString();
+    }
+
     const rawToken = `tuis_${randomBytes(32).toString("hex")}`;
     const tokenHash = hashToken(rawToken);
 
@@ -59,7 +72,7 @@ export async function POST(request: Request) {
       name,
       tokenHash,
       scopes: JSON.stringify(scopes),
-      expiresAt: expiresAt || null,
+      expiresAt: validatedExpiry,
     });
 
     return NextResponse.json(

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const user = await db
       .select()
@@ -33,6 +37,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const body = await request.json();
 
@@ -57,6 +64,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const result = await db.delete(users).where(eq(users.id, parseInt(id)));
 

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { users } from "@/lib/db/schema";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const allUsers = await db.select().from(users).orderBy(users.name);
     return NextResponse.json(allUsers);
   } catch (error) {
@@ -16,6 +20,9 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { name, color } = body;
 

--- a/src/app/api/vehicles/[id]/costs/route.ts
+++ b/src/app/api/vehicles/[id]/costs/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { vehicles, vehicleServices, fuelLogs } from "@/lib/db/schema";
 import { eq, sql, asc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
 

--- a/src/app/api/vehicles/[id]/fuel-analytics/route.ts
+++ b/src/app/api/vehicles/[id]/fuel-analytics/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { fuelLogs } from "@/lib/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { format, subMonths } from "date-fns";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +24,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
 

--- a/src/app/api/vehicles/[id]/fuel/route.ts
+++ b/src/app/api/vehicles/[id]/fuel/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { fuelLogs, vehicles } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
 
@@ -34,6 +38,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
     const body = await request.json();

--- a/src/app/api/vehicles/[id]/route.ts
+++ b/src/app/api/vehicles/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { vehicles, vehicleServices, fuelLogs, vendors } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
 
@@ -73,6 +77,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
     const body = await request.json();
@@ -124,6 +131,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
 

--- a/src/app/api/vehicles/[id]/services/route.ts
+++ b/src/app/api/vehicles/[id]/services/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { vehicleServices, vendors, vehicles } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
 
@@ -49,6 +53,9 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vehicleId = parseInt(id);
     const body = await request.json();

--- a/src/app/api/vehicles/route.ts
+++ b/src/app/api/vehicles/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { vehicles } from "@/lib/db/schema";
 import { like, or, desc, and } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const search = searchParams.get("search");
 
@@ -49,6 +53,9 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { name } = body;
 

--- a/src/app/api/vendors/[id]/route.ts
+++ b/src/app/api/vendors/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { vendors, completions, tasks, vehicleServices } from "@/lib/db/schema";
 import { eq, desc } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
@@ -10,6 +11,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vendorId = parseInt(id);
 
@@ -57,6 +61,9 @@ export async function PUT(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vendorId = parseInt(id);
     const body = await request.json();
@@ -99,6 +106,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { id } = await params;
     const vendorId = parseInt(id);
 

--- a/src/app/api/vendors/route.ts
+++ b/src/app/api/vendors/route.ts
@@ -2,11 +2,15 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { vendors } from "@/lib/db/schema";
 import { eq, like, or, desc, and } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const { searchParams } = new URL(request.url);
     const search = searchParams.get("search");
     const category = searchParams.get("category");
@@ -52,6 +56,9 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
     const body = await request.json();
     const { name, category, phone, email, website, notes, rating } = body;
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -14,6 +14,7 @@ import {
 import { User } from "@/types";
 import { Plus, Pencil, Trash2, Users } from "lucide-react";
 import { GoogleCalendarCard } from "@/components/settings/GoogleCalendarCard";
+import { PersonalAccessTokensCard } from "@/components/settings/PersonalAccessTokensCard";
 import { AppLayout } from "@/components/layout/AppLayout";
 
 const COLORS = [
@@ -112,6 +113,7 @@ export default function SettingsPage() {
     <AppLayout title="Settings">
       <div className="space-y-6 max-w-2xl">
         <GoogleCalendarCard />
+        <PersonalAccessTokensCard />
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">

--- a/src/components/settings/PersonalAccessTokensCard.tsx
+++ b/src/components/settings/PersonalAccessTokensCard.tsx
@@ -13,26 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { KeyRound, Plus, Trash2, Copy, Check } from "lucide-react";
-
-const SCOPE_GROUPS = {
-  tasks: { label: "Tasks", scopes: ["tasks:read", "tasks:write"] },
-  shopping: { label: "Shopping", scopes: ["shopping:read", "shopping:write"] },
-  meals: { label: "Meals", scopes: ["meals:read", "meals:write"] },
-  recipes: { label: "Recipes", scopes: ["recipes:read", "recipes:write"] },
-  vehicles: { label: "Vehicles", scopes: ["vehicles:read", "vehicles:write"] },
-  vendors: { label: "Vendors", scopes: ["vendors:read", "vendors:write"] },
-  quotes: { label: "Quotes", scopes: ["quotes:read", "quotes:write"] },
-  appliances: {
-    label: "Appliances",
-    scopes: ["appliances:read", "appliances:write"],
-  },
-  activities: {
-    label: "Activities",
-    scopes: ["activities:read", "activities:write"],
-  },
-  users: { label: "Users", scopes: ["users:read", "users:write"] },
-  stats: { label: "Stats", scopes: ["stats:read"] },
-} as const;
+import { SCOPE_GROUPS } from "@/lib/auth/scopes";
 
 interface TokenInfo {
   id: number;
@@ -52,6 +33,7 @@ export function PersonalAccessTokensCard() {
   const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
   const [newToken, setNewToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchTokens = async () => {
     try {
@@ -102,6 +84,7 @@ export function PersonalAccessTokensCard() {
     e.preventDefault();
     if (selectedScopes.size === 0) return;
     setIsSaving(true);
+    setError(null);
 
     try {
       const response = await fetch("/api/tokens", {
@@ -117,9 +100,12 @@ export function PersonalAccessTokensCard() {
         const data = await response.json();
         setNewToken(data.token);
         fetchTokens();
+      } else {
+        const data = await response.json().catch(() => null);
+        setError(data?.error || "Failed to create token");
       }
-    } catch (error) {
-      console.error("Error creating token:", error);
+    } catch {
+      setError("Network error — could not reach the server");
     } finally {
       setIsSaving(false);
     }
@@ -127,14 +113,19 @@ export function PersonalAccessTokensCard() {
 
   const handleDelete = async (token: TokenInfo) => {
     if (!confirm(`Revoke token "${token.name}"? This cannot be undone.`)) return;
+    setError(null);
 
     try {
       const response = await fetch(`/api/tokens/${token.id}`, {
         method: "DELETE",
       });
-      if (response.ok) fetchTokens();
-    } catch (error) {
-      console.error("Error deleting token:", error);
+      if (response.ok) {
+        fetchTokens();
+      } else {
+        setError("Failed to revoke token");
+      }
+    } catch {
+      setError("Network error — could not reach the server");
     }
   };
 
@@ -151,6 +142,7 @@ export function PersonalAccessTokensCard() {
     setSelectedScopes(new Set());
     setNewToken(null);
     setCopied(false);
+    setError(null);
   };
 
   const formatDate = (dateStr: string | null) => {
@@ -182,6 +174,11 @@ export function PersonalAccessTokensCard() {
         </Button>
       </CardHeader>
       <CardContent>
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-950/50 text-red-700 dark:text-red-400 rounded-lg text-sm">
+            {error}
+          </div>
+        )}
         {isLoading ? (
           <p className="text-muted-foreground text-center py-8">Loading...</p>
         ) : tokens.length === 0 ? (

--- a/src/components/settings/PersonalAccessTokensCard.tsx
+++ b/src/components/settings/PersonalAccessTokensCard.tsx
@@ -147,7 +147,9 @@ export function PersonalAccessTokensCard() {
 
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return "Never";
-    return new Date(dateStr).toLocaleDateString();
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return "Just now";
+    return d.toLocaleDateString();
   };
 
   const parsedScopes = (scopesJson: string): string[] => {

--- a/src/components/settings/PersonalAccessTokensCard.tsx
+++ b/src/components/settings/PersonalAccessTokensCard.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { KeyRound, Plus, Trash2, Copy, Check } from "lucide-react";
+
+const SCOPE_GROUPS = {
+  tasks: { label: "Tasks", scopes: ["tasks:read", "tasks:write"] },
+  shopping: { label: "Shopping", scopes: ["shopping:read", "shopping:write"] },
+  meals: { label: "Meals", scopes: ["meals:read", "meals:write"] },
+  recipes: { label: "Recipes", scopes: ["recipes:read", "recipes:write"] },
+  vehicles: { label: "Vehicles", scopes: ["vehicles:read", "vehicles:write"] },
+  vendors: { label: "Vendors", scopes: ["vendors:read", "vendors:write"] },
+  quotes: { label: "Quotes", scopes: ["quotes:read", "quotes:write"] },
+  appliances: {
+    label: "Appliances",
+    scopes: ["appliances:read", "appliances:write"],
+  },
+  activities: {
+    label: "Activities",
+    scopes: ["activities:read", "activities:write"],
+  },
+  users: { label: "Users", scopes: ["users:read", "users:write"] },
+  stats: { label: "Stats", scopes: ["stats:read"] },
+} as const;
+
+interface TokenInfo {
+  id: number;
+  name: string;
+  scopes: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export function PersonalAccessTokensCard() {
+  const [tokens, setTokens] = useState<TokenInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [name, setName] = useState("");
+  const [selectedScopes, setSelectedScopes] = useState<Set<string>>(new Set());
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const fetchTokens = async () => {
+    try {
+      const response = await fetch("/api/tokens");
+      if (response.ok) {
+        setTokens(await response.json());
+      }
+    } catch (error) {
+      console.error("Error fetching tokens:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTokens();
+  }, []);
+
+  const toggleScope = (scope: string) => {
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      if (next.has(scope)) next.delete(scope);
+      else next.add(scope);
+      return next;
+    });
+  };
+
+  const toggleGroup = (groupKey: string) => {
+    const group =
+      SCOPE_GROUPS[groupKey as keyof typeof SCOPE_GROUPS];
+    const allSelected = group.scopes.every((s) => selectedScopes.has(s));
+    setSelectedScopes((prev) => {
+      const next = new Set(prev);
+      for (const s of group.scopes) {
+        if (allSelected) next.delete(s);
+        else next.add(s);
+      }
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    const all = Object.values(SCOPE_GROUPS).flatMap((g) => g.scopes);
+    setSelectedScopes(new Set(all));
+  };
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (selectedScopes.size === 0) return;
+    setIsSaving(true);
+
+    try {
+      const response = await fetch("/api/tokens", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          scopes: Array.from(selectedScopes),
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setNewToken(data.token);
+        fetchTokens();
+      }
+    } catch (error) {
+      console.error("Error creating token:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (token: TokenInfo) => {
+    if (!confirm(`Revoke token "${token.name}"? This cannot be undone.`)) return;
+
+    try {
+      const response = await fetch(`/api/tokens/${token.id}`, {
+        method: "DELETE",
+      });
+      if (response.ok) fetchTokens();
+    } catch (error) {
+      console.error("Error deleting token:", error);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!newToken) return;
+    await navigator.clipboard.writeText(newToken);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const closeForm = () => {
+    setIsFormOpen(false);
+    setName("");
+    setSelectedScopes(new Set());
+    setNewToken(null);
+    setCopied(false);
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return "Never";
+    return new Date(dateStr).toLocaleDateString();
+  };
+
+  const parsedScopes = (scopesJson: string): string[] => {
+    try {
+      return JSON.parse(scopesJson);
+    } catch {
+      return [];
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="flex items-center gap-2">
+          <KeyRound className="h-5 w-5" />
+          Personal Access Tokens
+        </CardTitle>
+        <Button
+          onClick={() => setIsFormOpen(true)}
+          size="sm"
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Create Token
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p className="text-muted-foreground text-center py-8">Loading...</p>
+        ) : tokens.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">
+            No tokens yet. Create one to use with the CLI.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {tokens.map((token) => (
+              <div
+                key={token.id}
+                className="flex items-center justify-between p-3 bg-gray-50 dark:bg-zinc-900 rounded-lg"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium truncate">{token.name}</p>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {parsedScopes(token.scopes).map((scope) => (
+                      <span
+                        key={scope}
+                        className="text-xs px-1.5 py-0.5 bg-gray-200 dark:bg-zinc-700 rounded"
+                      >
+                        {scope}
+                      </span>
+                    ))}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Created {formatDate(token.createdAt)}
+                    {token.lastUsedAt &&
+                      ` \u00B7 Last used ${formatDate(token.lastUsedAt)}`}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 ml-2 shrink-0"
+                  onClick={() => handleDelete(token)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={isFormOpen} onOpenChange={(open) => !open && closeForm()}>
+        <DialogContent className="sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle>
+              {newToken ? "Token Created" : "Create Access Token"}
+            </DialogTitle>
+          </DialogHeader>
+
+          {newToken ? (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Copy this token now. It will not be shown again.
+              </p>
+              <div className="flex gap-2">
+                <Input
+                  readOnly
+                  value={newToken}
+                  className="font-mono text-xs"
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCopy}
+                  className="shrink-0"
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+              <div className="flex justify-end">
+                <Button onClick={closeForm}>Done</Button>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="token-name">Token Name</Label>
+                <Input
+                  id="token-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g., CLI, Home Assistant"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Scopes</Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs h-auto py-1"
+                    onClick={selectAll}
+                  >
+                    Select all
+                  </Button>
+                </div>
+                <div className="grid grid-cols-2 gap-3 max-h-64 overflow-y-auto border rounded-lg p-3 dark:border-zinc-700">
+                  {Object.entries(SCOPE_GROUPS).map(([key, group]) => (
+                    <div key={key} className="space-y-1">
+                      <button
+                        type="button"
+                        className="text-sm font-medium hover:underline"
+                        onClick={() => toggleGroup(key)}
+                      >
+                        {group.label}
+                      </button>
+                      {group.scopes.map((scope) => (
+                        <label
+                          key={scope}
+                          className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer"
+                        >
+                          <Checkbox
+                            checked={selectedScopes.has(scope)}
+                            onCheckedChange={() => toggleScope(scope)}
+                          />
+                          {scope.split(":")[1]}
+                        </label>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-2 pt-2">
+                <Button type="button" variant="outline" onClick={closeForm}>
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isSaving || selectedScopes.size === 0}
+                >
+                  {isSaving ? "Creating..." : "Create"}
+                </Button>
+              </div>
+            </form>
+          )}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/lib/auth/scopes.ts
+++ b/src/lib/auth/scopes.ts
@@ -1,0 +1,44 @@
+export const SCOPE_GROUPS = {
+  tasks: { label: "Tasks", scopes: ["tasks:read", "tasks:write"] },
+  shopping: { label: "Shopping", scopes: ["shopping:read", "shopping:write"] },
+  meals: { label: "Meals", scopes: ["meals:read", "meals:write"] },
+  recipes: { label: "Recipes", scopes: ["recipes:read", "recipes:write"] },
+  vehicles: { label: "Vehicles", scopes: ["vehicles:read", "vehicles:write"] },
+  vendors: { label: "Vendors", scopes: ["vendors:read", "vendors:write"] },
+  quotes: { label: "Quotes", scopes: ["quotes:read", "quotes:write"] },
+  appliances: {
+    label: "Appliances",
+    scopes: ["appliances:read", "appliances:write"],
+  },
+  activities: {
+    label: "Activities",
+    scopes: ["activities:read", "activities:write"],
+  },
+  users: { label: "Users", scopes: ["users:read", "users:write"] },
+  stats: { label: "Stats", scopes: ["stats:read"] },
+} as const;
+
+export type Scope = (typeof ALL_SCOPES)[number];
+
+export const ALL_SCOPES = Object.values(SCOPE_GROUPS).flatMap(
+  (g) => g.scopes
+) as string[];
+
+// Map API route prefixes to required scopes
+export const ROUTE_SCOPE_MAP: Record<string, { read: string; write: string }> =
+  {
+    "/api/tasks": { read: "tasks:read", write: "tasks:write" },
+    "/api/shopping": { read: "shopping:read", write: "shopping:write" },
+    "/api/meals": { read: "meals:read", write: "meals:write" },
+    "/api/recipes": { read: "recipes:read", write: "recipes:write" },
+    "/api/vehicles": { read: "vehicles:read", write: "vehicles:write" },
+    "/api/vendors": { read: "vendors:read", write: "vendors:write" },
+    "/api/quotes": { read: "quotes:read", write: "quotes:write" },
+    "/api/appliances": {
+      read: "appliances:read",
+      write: "appliances:write",
+    },
+    "/api/together": { read: "activities:read", write: "activities:write" },
+    "/api/users": { read: "users:read", write: "users:write" },
+    "/api/stats": { read: "stats:read", write: "stats:read" },
+  };

--- a/src/lib/auth/scopes.ts
+++ b/src/lib/auth/scopes.ts
@@ -40,5 +40,5 @@ export const ROUTE_SCOPE_MAP: Record<string, { read: string; write: string }> =
     },
     "/api/together": { read: "activities:read", write: "activities:write" },
     "/api/users": { read: "users:read", write: "users:write" },
-    "/api/stats": { read: "stats:read", write: "stats:read" },
+    "/api/stats": { read: "stats:read", write: "stats:read" },  // read-only resource
   };

--- a/src/lib/auth/validate.ts
+++ b/src/lib/auth/validate.ts
@@ -1,0 +1,102 @@
+import { createHash } from "crypto";
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { personalAccessTokens } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { ROUTE_SCOPE_MAP } from "./scopes";
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export { hashToken };
+
+/**
+ * Validate a request against PAT auth.
+ * - No Authorization header → allow (web UI, backward compat)
+ * - Bearer token present → validate hash, expiry, scope
+ * Returns null if allowed, or a NextResponse error.
+ */
+export async function validateRequest(
+  request: Request,
+  requiredScope: string
+): Promise<NextResponse | null> {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader) return null; // No auth header = web UI, allow
+
+  if (!authHeader.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Invalid authorization header" },
+      { status: 401 }
+    );
+  }
+
+  const rawToken = authHeader.slice(7);
+  if (!rawToken.startsWith("tuis_")) {
+    return NextResponse.json(
+      { error: "Invalid token format" },
+      { status: 401 }
+    );
+  }
+
+  const hash = hashToken(rawToken);
+  const results = await db
+    .select()
+    .from(personalAccessTokens)
+    .where(eq(personalAccessTokens.tokenHash, hash))
+    .limit(1);
+
+  if (results.length === 0) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const pat = results[0];
+
+  // Check expiry
+  if (pat.expiresAt && new Date(pat.expiresAt) < new Date()) {
+    return NextResponse.json({ error: "Token expired" }, { status: 401 });
+  }
+
+  // Check scope
+  const scopes: string[] = JSON.parse(pat.scopes);
+  if (!scopes.includes(requiredScope)) {
+    return NextResponse.json(
+      { error: `Missing scope: ${requiredScope}` },
+      { status: 403 }
+    );
+  }
+
+  // Update last used (fire-and-forget)
+  db.update(personalAccessTokens)
+    .set({ lastUsedAt: new Date().toISOString() })
+    .where(eq(personalAccessTokens.id, pat.id))
+    .then(() => {})
+    .catch(() => {});
+
+  return null;
+}
+
+/**
+ * Derive the required scope from a request's URL and method.
+ * Returns the scope string or null if the route is not protected.
+ */
+export function scopeForRoute(pathname: string, method: string): string | null {
+  for (const [prefix, scopes] of Object.entries(ROUTE_SCOPE_MAP)) {
+    if (pathname.startsWith(prefix)) {
+      return method === "GET" ? scopes.read : scopes.write;
+    }
+  }
+  return null;
+}
+
+/**
+ * Convenience: validate a request using automatic scope detection.
+ */
+export async function validateApiRequest(
+  request: Request
+): Promise<NextResponse | null> {
+  const url = new URL(request.url);
+  const scope = scopeForRoute(url.pathname, request.method);
+  if (!scope) return null; // Route not in scope map, allow
+  return validateRequest(request, scope);
+}

--- a/src/lib/auth/validate.ts
+++ b/src/lib/auth/validate.ts
@@ -13,6 +13,13 @@ export { hashToken };
 
 /**
  * Validate a request against PAT auth.
+ *
+ * Security model: Tuis is a self-hosted household app with no user auth.
+ * PATs are a **restriction mechanism** for programmatic/CLI clients, not an
+ * access-control boundary. Requests without an Authorization header get full
+ * access (same as the web UI). Only requests that present a Bearer token are
+ * validated against scopes and expiry.
+ *
  * - No Authorization header → allow (web UI, backward compat)
  * - Bearer token present → validate hash, expiry, scope
  * Returns null if allowed, or a NextResponse error.
@@ -52,16 +59,27 @@ export async function validateRequest(
 
   const pat = results[0];
 
-  // Check expiry
-  if (pat.expiresAt && new Date(pat.expiresAt) < new Date()) {
-    return NextResponse.json({ error: "Token expired" }, { status: 401 });
+  // Check expiry — reject if expiresAt is set and is a valid past date
+  if (pat.expiresAt) {
+    const expiry = new Date(pat.expiresAt);
+    if (isNaN(expiry.getTime()) || expiry < new Date()) {
+      return NextResponse.json({ error: "Token expired" }, { status: 401 });
+    }
   }
 
   // Check scope
-  const scopes: string[] = JSON.parse(pat.scopes);
+  let scopes: string[];
+  try {
+    scopes = JSON.parse(pat.scopes);
+  } catch {
+    return NextResponse.json(
+      { error: "Token has invalid scope data" },
+      { status: 401 }
+    );
+  }
   if (!scopes.includes(requiredScope)) {
     return NextResponse.json(
-      { error: `Missing scope: ${requiredScope}` },
+      { error: "Insufficient scope" },
       { status: 403 }
     );
   }

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -252,6 +252,16 @@ function initDb(): BetterSQLite3Database<typeof schema> {
       notes TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
+
+    CREATE TABLE IF NOT EXISTS personal_access_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      scopes TEXT NOT NULL,
+      last_used_at TEXT,
+      expires_at TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
   `);
 
   // Add new columns if they don't exist (migrations for existing databases)

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -283,5 +283,17 @@ export type Vehicle = typeof vehicles.$inferSelect;
 export type NewVehicle = typeof vehicles.$inferInsert;
 export type VehicleService = typeof vehicleServices.$inferSelect;
 export type NewVehicleService = typeof vehicleServices.$inferInsert;
+export const personalAccessTokens = sqliteTable("personal_access_tokens", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  tokenHash: text("token_hash").notNull().unique(),
+  scopes: text("scopes").notNull(), // JSON string array
+  lastUsedAt: text("last_used_at"),
+  expiresAt: text("expires_at"),
+  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
+});
+
 export type FuelLog = typeof fuelLogs.$inferSelect;
 export type NewFuelLog = typeof fuelLogs.$inferInsert;
+export type PersonalAccessToken = typeof personalAccessTokens.$inferSelect;
+export type NewPersonalAccessToken = typeof personalAccessTokens.$inferInsert;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "mcp-server"]
+  "exclude": ["node_modules", "mcp-server", "cli"]
 }


### PR DESCRIPTION
## Summary
- **CLI** (`cli/`): Commander.js-based CLI with `tuis configure` + full CRUD commands for all resources (tasks, shopping, recipes, meals, vehicles, vendors, quotes, appliances, activities, users, stats)
- **PAT auth system**: `personal_access_tokens` table with SHA-256 hashed storage, 21 scopes across 11 resource groups, scope-based validation wired into all 36 API route handlers. Web UI continues to work without auth (no `Authorization` header = full access).
- **Settings UI**: `PersonalAccessTokensCard` with create (name + scope checkboxes), one-time token reveal with copy, list, and delete
- **Tests**: 15 new unit tests (token CRUD, auth validation), e2e test for Settings PAT flow + API auth enforcement. All 59 existing tests pass.

## Test plan
- [x] `npm test` — 59 unit tests pass (including 15 new token/auth tests)
- [x] `npx tsc --noEmit` — clean type-check
- [x] `npm run lint` — no new errors
- [x] `npm run test:e2e` — new `tokens.spec.ts` covers create/delete/auth flow
- [x] Manual: create a PAT in Settings, verify token shown once, API auth works — [proof](https://github.com/heuwels/tuis/pull/49#issuecomment-4275967047)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
