### PR TITLE
Add Docker Compose wizard for deployment config

### DIFF
--- a/e2e/docker-wizard.spec.ts
+++ b/e2e/docker-wizard.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "@playwright/test";
+
+test.describe.serial("Docker Compose Wizard", () => {
+  test("loads the wizard page with core settings step", async ({ page }) => {
+    await page.goto("/setup/docker-wizard");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { name: "Docker Compose Wizard" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Core Settings" })
+    ).toBeVisible();
+
+    // Default values should be present
+    await expect(page.locator("#port")).toHaveValue("6969");
+    await expect(page.locator("#volume")).toHaveValue("tuis-data");
+    await expect(page.locator("#image-tag")).toHaveValue("latest");
+  });
+
+  test("navigates through all wizard steps", async ({ page }) => {
+    await page.goto("/setup/docker-wizard");
+    await page.waitForLoadState("networkidle");
+
+    // Step 0: Core Settings
+    await expect(
+      page.getByRole("heading", { name: "Core Settings" })
+    ).toBeVisible();
+
+    // Change port
+    await page.locator("#port").fill("8080");
+
+    // Go to step 1
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Step 1: Sidecars
+    await expect(
+      page.getByRole("heading", { name: "Sidecars" })
+    ).toBeVisible();
+    await expect(page.getByText("MCP Server")).toBeVisible();
+    await expect(page.getByText("More coming soon")).toBeVisible();
+
+    // Enable MCP sidecar
+    await page
+      .locator("label")
+      .filter({ hasText: "MCP Server" })
+      .click();
+
+    // Go to step 2
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Step 2: Environment Variables
+    await expect(
+      page.getByRole("heading", { name: "Environment Variables" })
+    ).toBeVisible();
+    await expect(page.getByLabel("NextAuth Secret")).toBeVisible();
+    await expect(page.getByLabel("Google Client ID")).toBeVisible();
+
+    // Go to step 3
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    // Step 3: Preview
+    await expect(
+      page.getByRole("heading", { name: "Your docker-compose.yml" })
+    ).toBeVisible();
+  });
+
+  test("generated YAML reflects user configuration", async ({ page }) => {
+    await page.goto("/setup/docker-wizard");
+    await page.waitForLoadState("networkidle");
+
+    // Set custom port
+    await page.locator("#port").fill("9090");
+
+    // Continue to sidecars
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Enable MCP
+    await page
+      .locator("label")
+      .filter({ hasText: "MCP Server" })
+      .click();
+
+    // Continue to env vars
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    // Continue to preview
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    // Verify the YAML content
+    const yamlPreview = page.getByTestId("yaml-preview");
+    const yamlText = await yamlPreview.textContent();
+
+    expect(yamlText).toContain("9090");
+    expect(yamlText).toContain("mcp-server:");
+    expect(yamlText).toContain("tuis-mcp");
+    expect(yamlText).toContain("ghcr.io/heuwels/tuis");
+    expect(yamlText).toContain("tuis-data:/app/data");
+  });
+
+  test("back navigation works through all steps", async ({ page }) => {
+    await page.goto("/setup/docker-wizard");
+    await page.waitForLoadState("networkidle");
+
+    // Navigate forward to preview
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Your docker-compose.yml" })
+    ).toBeVisible();
+
+    // Navigate back step by step
+    await page.getByRole("button", { name: "Back" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Environment Variables" })
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Back" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Sidecars" })
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Back" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Core Settings" })
+    ).toBeVisible();
+  });
+
+  test("copy and download buttons are present on preview", async ({
+    page,
+  }) => {
+    await page.goto("/setup/docker-wizard");
+    await page.waitForLoadState("networkidle");
+
+    // Navigate to preview
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Copy to Clipboard" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Download File" })
+    ).toBeVisible();
+  });
+
+  test("default YAML without sidecars does not contain mcp-server", async ({
+    page,
+  }) => {
+    await page.goto("/setup/docker-wizard");
+    await page.waitForLoadState("networkidle");
+
+    // Navigate straight to preview without enabling anything
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    const yamlPreview = page.getByTestId("yaml-preview");
+    const yamlText = await yamlPreview.textContent();
+
+    expect(yamlText).toContain("tuis:");
+    expect(yamlText).not.toContain("mcp-server:");
+    expect(yamlText).toContain("NODE_ENV=production");
+  });
+});

--- a/src/app/api/__tests__/docker-compose.test.ts
+++ b/src/app/api/__tests__/docker-compose.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateDockerCompose,
+  DEFAULT_CONFIG,
+} from "@/lib/docker-compose";
+
+describe("Docker Compose Generator", () => {
+  describe("default config", () => {
+    it("produces valid YAML starting with services:", () => {
+      const yaml = generateDockerCompose();
+      expect(yaml).toMatch(/^services:\n/);
+    });
+
+    it("includes the tuis service with correct image", () => {
+      const yaml = generateDockerCompose();
+      expect(yaml).toContain("  tuis:");
+      expect(yaml).toContain("image: ghcr.io/heuwels/tuis:${TUIS_VERSION:-latest}");
+    });
+
+    it("maps the default port 6969", () => {
+      const yaml = generateDockerCompose();
+      expect(yaml).toContain("${WEB_PORT:-6969}:3000");
+    });
+
+    it("uses the default named volume tuis-data", () => {
+      const yaml = generateDockerCompose();
+      expect(yaml).toContain("tuis-data:/app/data");
+      expect(yaml).toContain("volumes:\n  tuis-data:");
+    });
+
+    it("includes standard environment variables", () => {
+      const yaml = generateDockerCompose();
+      expect(yaml).toContain("NODE_ENV=production");
+      expect(yaml).toContain("NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}");
+      expect(yaml).toContain("GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}");
+      expect(yaml).toContain("GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}");
+      expect(yaml).toContain("NEXTAUTH_SECRET=${NEXTAUTH_SECRET}");
+    });
+
+    it("does not include MCP sidecar by default", () => {
+      const yaml = generateDockerCompose();
+      expect(yaml).not.toContain("mcp-server:");
+      expect(yaml).not.toContain("tuis-mcp");
+    });
+  });
+
+  describe("custom port", () => {
+    it("uses the specified port", () => {
+      const yaml = generateDockerCompose({ port: 8080 });
+      expect(yaml).toContain("${WEB_PORT:-8080}:3000");
+      expect(yaml).not.toContain("${WEB_PORT:-6969}");
+    });
+  });
+
+  describe("custom volume path", () => {
+    it("uses a named volume when given a simple name", () => {
+      const yaml = generateDockerCompose({ volumePath: "my-data" });
+      expect(yaml).toContain("my-data:/app/data");
+      expect(yaml).toContain("volumes:\n  my-data:");
+    });
+
+    it("uses a bind mount path and omits named volumes section", () => {
+      const yaml = generateDockerCompose({ volumePath: "./data" });
+      expect(yaml).toContain("./data:/app/data");
+      // No named volumes section when using a bind mount
+      const volumesSections = yaml.split("volumes:");
+      // Only the service-level volumes: should appear, not a top-level volumes:
+      expect(volumesSections).toHaveLength(2); // one in service, no top-level
+    });
+
+    it("handles absolute host paths", () => {
+      const yaml = generateDockerCompose({ volumePath: "/opt/tuis/data" });
+      expect(yaml).toContain("/opt/tuis/data:/app/data");
+    });
+  });
+
+  describe("custom image tag", () => {
+    it("uses the specified image tag", () => {
+      const yaml = generateDockerCompose({ imageTag: "v1.2.3" });
+      expect(yaml).toContain("ghcr.io/heuwels/tuis:${TUIS_VERSION:-v1.2.3}");
+    });
+  });
+
+  describe("MCP sidecar", () => {
+    it("adds mcp-server service when enabled", () => {
+      const yaml = generateDockerCompose({ includeMcp: true });
+      expect(yaml).toContain("  mcp-server:");
+      expect(yaml).toContain("container_name: tuis-mcp");
+      expect(yaml).toContain("TUIS_API_URL=http://tuis:3000");
+    });
+
+    it("MCP sidecar depends on tuis service", () => {
+      const yaml = generateDockerCompose({ includeMcp: true });
+      expect(yaml).toContain("depends_on:");
+      expect(yaml).toContain("      - tuis");
+    });
+
+    it("MCP sidecar uses the same image tag", () => {
+      const yaml = generateDockerCompose({
+        includeMcp: true,
+        imageTag: "v2.0.0",
+      });
+      // Both services should reference the same tag
+      const matches = yaml.match(/ghcr\.io\/heuwels\/tuis:\$\{TUIS_VERSION:-v2\.0\.0\}/g);
+      expect(matches).toHaveLength(2);
+    });
+  });
+
+  describe("environment variables", () => {
+    it("includes user-provided values with defaults", () => {
+      const yaml = generateDockerCompose({
+        envVars: {
+          NEXTAUTH_SECRET: "my-secret-key",
+        },
+      });
+      expect(yaml).toContain("NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-my-secret-key}");
+    });
+
+    it("includes custom env vars", () => {
+      const yaml = generateDockerCompose({
+        envVars: {
+          MY_CUSTOM_VAR: "hello",
+        },
+      });
+      expect(yaml).toContain("MY_CUSTOM_VAR=hello");
+    });
+
+    it("allows overriding NEXTAUTH_URL default", () => {
+      const yaml = generateDockerCompose({
+        envVars: {
+          NEXTAUTH_URL: "https://tuis.example.com",
+        },
+      });
+      expect(yaml).toContain("NEXTAUTH_URL=${NEXTAUTH_URL:-https://tuis.example.com}");
+    });
+  });
+
+  describe("DEFAULT_CONFIG", () => {
+    it("has sensible defaults", () => {
+      expect(DEFAULT_CONFIG.port).toBe(6969);
+      expect(DEFAULT_CONFIG.volumePath).toBe("tuis-data");
+      expect(DEFAULT_CONFIG.imageTag).toBe("latest");
+      expect(DEFAULT_CONFIG.includeMcp).toBe(false);
+      expect(DEFAULT_CONFIG.envVars).toEqual({});
+    });
+  });
+});

--- a/src/app/setup/docker-wizard/page.tsx
+++ b/src/app/setup/docker-wizard/page.tsx
@@ -1,0 +1,5 @@
+import DockerWizard from "@/components/setup/DockerWizard";
+
+export default function DockerWizardPage() {
+  return <DockerWizard />;
+}

--- a/src/components/setup/DockerWizard.tsx
+++ b/src/components/setup/DockerWizard.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import {
+  Settings,
+  Puzzle,
+  Variable,
+  FileCode,
+  ArrowRight,
+  ArrowLeft,
+  Copy,
+  Download,
+  Check,
+  Container,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import {
+  generateDockerCompose,
+  DEFAULT_CONFIG,
+  type DockerComposeConfig,
+} from "@/lib/docker-compose";
+
+const STEPS = [
+  { label: "Core", icon: Settings },
+  { label: "Sidecars", icon: Puzzle },
+  { label: "Environment", icon: Variable },
+  { label: "Preview", icon: FileCode },
+];
+
+const KNOWN_ENV_VARS: Array<{
+  key: string;
+  label: string;
+  description: string;
+  placeholder: string;
+}> = [
+  {
+    key: "NEXTAUTH_SECRET",
+    label: "NextAuth Secret",
+    description: "Secret key for session encryption",
+    placeholder: "e.g. openssl rand -base64 32",
+  },
+  {
+    key: "NEXTAUTH_URL",
+    label: "NextAuth URL",
+    description: "Public URL of your Tuis instance",
+    placeholder: "http://localhost:3000",
+  },
+  {
+    key: "GOOGLE_CLIENT_ID",
+    label: "Google Client ID",
+    description: "For Google Calendar integration (optional)",
+    placeholder: "your-client-id.apps.googleusercontent.com",
+  },
+  {
+    key: "GOOGLE_CLIENT_SECRET",
+    label: "Google Client Secret",
+    description: "For Google Calendar integration (optional)",
+    placeholder: "your-client-secret",
+  },
+  {
+    key: "ACTUAL_API_URL",
+    label: "Actual Budget API URL",
+    description: "URL of your Actual Budget server (optional)",
+    placeholder: "http://localhost:3100",
+  },
+];
+
+interface CustomEnvVar {
+  key: string;
+  value: string;
+}
+
+export default function DockerWizard() {
+  const [step, setStep] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  // Step 1: Core settings
+  const [port, setPort] = useState(DEFAULT_CONFIG.port);
+  const [volumePath, setVolumePath] = useState(DEFAULT_CONFIG.volumePath);
+  const [imageTag, setImageTag] = useState(DEFAULT_CONFIG.imageTag);
+
+  // Step 2: Sidecars
+  const [includeMcp, setIncludeMcp] = useState(false);
+
+  // Step 3: Environment
+  const [envValues, setEnvValues] = useState<Record<string, string>>({});
+  const [customEnvVars, setCustomEnvVars] = useState<CustomEnvVar[]>([]);
+
+  const updateEnvValue = useCallback((key: string, value: string) => {
+    setEnvValues((prev) => {
+      if (value === "") {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      }
+      return { ...prev, [key]: value };
+    });
+  }, []);
+
+  const addCustomEnvVar = useCallback(() => {
+    setCustomEnvVars((prev) => [...prev, { key: "", value: "" }]);
+  }, []);
+
+  const updateCustomEnvVar = useCallback(
+    (index: number, field: "key" | "value", val: string) => {
+      setCustomEnvVars((prev) => {
+        const next = [...prev];
+        next[index] = { ...next[index], [field]: val };
+        return next;
+      });
+    },
+    []
+  );
+
+  const removeCustomEnvVar = useCallback((index: number) => {
+    setCustomEnvVars((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  // Build config and generate YAML
+  const buildConfig = useCallback((): Partial<DockerComposeConfig> => {
+    const allEnvVars: Record<string, string> = { ...envValues };
+    for (const { key, value } of customEnvVars) {
+      if (key.trim() && value.trim()) {
+        allEnvVars[key.trim()] = value.trim();
+      }
+    }
+    return {
+      port,
+      volumePath,
+      imageTag,
+      includeMcp,
+      envVars: allEnvVars,
+    };
+  }, [port, volumePath, imageTag, includeMcp, envValues, customEnvVars]);
+
+  const generatedYaml = generateDockerCompose(buildConfig());
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(generatedYaml);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for non-secure contexts
+      const textarea = document.createElement("textarea");
+      textarea.value = generatedYaml;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [generatedYaml]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([generatedYaml], { type: "text/yaml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "docker-compose.yml";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [generatedYaml]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-zinc-950 flex items-center justify-center p-4">
+      <div className="w-full max-w-lg">
+        {/* Header */}
+        <div className="text-center mb-6">
+          <div className="flex justify-center mb-3">
+            <div className="w-12 h-12 rounded-xl bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+              <Container className="h-6 w-6 text-blue-600" />
+            </div>
+          </div>
+          <h1 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
+            Docker Compose Wizard
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-zinc-400 mt-1">
+            Generate a docker-compose.yml tailored to your setup
+          </p>
+        </div>
+
+        {/* Progress indicator */}
+        <div className="flex items-center justify-center gap-2 mb-8">
+          {STEPS.map((s, i) => {
+            const Icon = s.icon;
+            return (
+              <div key={s.label} className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => setStep(i)}
+                  className={`flex items-center justify-center w-9 h-9 rounded-full transition-colors ${
+                    i <= step
+                      ? "bg-blue-600 text-white"
+                      : "bg-gray-200 dark:bg-zinc-700 text-gray-400 dark:text-zinc-500"
+                  }`}
+                  aria-label={`Go to step: ${s.label}`}
+                >
+                  <Icon className="h-4 w-4" />
+                </button>
+                {i < STEPS.length - 1 && (
+                  <div
+                    className={`w-8 h-0.5 transition-colors ${
+                      i < step
+                        ? "bg-blue-600"
+                        : "bg-gray-200 dark:bg-zinc-700"
+                    }`}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Step 0: Core Settings */}
+        {step === 0 && (
+          <Card>
+            <CardContent className="pt-6 pb-6 space-y-6">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
+                  Core Settings
+                </h2>
+                <p className="text-gray-500 dark:text-zinc-400 text-sm">
+                  Configure the basics for your Tuis deployment.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="port">Host Port</Label>
+                  <Input
+                    id="port"
+                    type="number"
+                    value={port}
+                    onChange={(e) =>
+                      setPort(parseInt(e.target.value, 10) || 6969)
+                    }
+                    placeholder="6969"
+                    min={1}
+                    max={65535}
+                  />
+                  <p className="text-xs text-gray-500 dark:text-zinc-400">
+                    The port on your host machine to access Tuis (maps to
+                    container port 3000).
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="volume">Data Volume</Label>
+                  <Input
+                    id="volume"
+                    value={volumePath}
+                    onChange={(e) => setVolumePath(e.target.value || "tuis-data")}
+                    placeholder="tuis-data"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-zinc-400">
+                    A named Docker volume (e.g. &quot;tuis-data&quot;) or a host path
+                    (e.g. &quot;./data&quot; or &quot;/opt/tuis/data&quot;) for database
+                    persistence.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="image-tag">Image Tag</Label>
+                  <Input
+                    id="image-tag"
+                    value={imageTag}
+                    onChange={(e) => setImageTag(e.target.value || "latest")}
+                    placeholder="latest"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-zinc-400">
+                    The default image tag. Can be overridden at runtime with the
+                    TUIS_VERSION env var.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex justify-end">
+                <Button onClick={() => setStep(1)} className="gap-2">
+                  Continue
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 1: Sidecars */}
+        {step === 1 && (
+          <Card>
+            <CardContent className="pt-6 pb-6 space-y-6">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
+                  Sidecars
+                </h2>
+                <p className="text-gray-500 dark:text-zinc-400 text-sm">
+                  Add optional companion services alongside the main Tuis app.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <label className="flex items-start gap-3 p-4 bg-gray-50 dark:bg-zinc-800 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors">
+                  <Checkbox
+                    checked={includeMcp}
+                    onCheckedChange={(checked) =>
+                      setIncludeMcp(checked === true)
+                    }
+                    className="mt-0.5"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-gray-900 dark:text-zinc-100">
+                        MCP Server
+                      </span>
+                      <Badge variant="secondary">Sidecar</Badge>
+                    </div>
+                    <div className="text-sm text-gray-500 dark:text-zinc-400 mt-1">
+                      Model Context Protocol server for AI assistant
+                      integrations. Connects to the Tuis API to allow AI tools
+                      to manage your household data.
+                    </div>
+                  </div>
+                </label>
+
+                <div className="p-4 bg-gray-50 dark:bg-zinc-800 rounded-lg opacity-60">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-gray-900 dark:text-zinc-100">
+                      More coming soon
+                    </span>
+                    <Badge variant="outline">Planned</Badge>
+                  </div>
+                  <div className="text-sm text-gray-500 dark:text-zinc-400 mt-1">
+                    Additional adapters and integrations will be available in
+                    future releases.
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={() => setStep(0)}
+                  className="gap-2"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </Button>
+                <Button
+                  onClick={() => setStep(2)}
+                  className="flex-1 gap-2"
+                >
+                  Continue
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 2: Environment Variables */}
+        {step === 2 && (
+          <Card>
+            <CardContent className="pt-6 pb-6 space-y-6">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
+                  Environment Variables
+                </h2>
+                <p className="text-gray-500 dark:text-zinc-400 text-sm">
+                  Optionally pre-fill environment variable defaults. Leave blank
+                  to use shell variable references in the output.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                {KNOWN_ENV_VARS.map((envVar) => (
+                  <div key={envVar.key} className="space-y-1.5">
+                    <Label htmlFor={`env-${envVar.key}`}>{envVar.label}</Label>
+                    <Input
+                      id={`env-${envVar.key}`}
+                      value={envValues[envVar.key] || ""}
+                      onChange={(e) =>
+                        updateEnvValue(envVar.key, e.target.value)
+                      }
+                      placeholder={envVar.placeholder}
+                    />
+                    <p className="text-xs text-gray-500 dark:text-zinc-400">
+                      {envVar.description}
+                    </p>
+                  </div>
+                ))}
+
+                {/* Custom env vars */}
+                {customEnvVars.length > 0 && (
+                  <div className="border-t border-gray-200 dark:border-zinc-700 pt-4 space-y-3">
+                    <Label>Custom Variables</Label>
+                    {customEnvVars.map((envVar, index) => (
+                      <div key={index} className="flex gap-2">
+                        <Input
+                          value={envVar.key}
+                          onChange={(e) =>
+                            updateCustomEnvVar(index, "key", e.target.value)
+                          }
+                          placeholder="KEY"
+                          className="flex-1"
+                        />
+                        <Input
+                          value={envVar.value}
+                          onChange={(e) =>
+                            updateCustomEnvVar(index, "value", e.target.value)
+                          }
+                          placeholder="value"
+                          className="flex-1"
+                        />
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeCustomEnvVar(index)}
+                          className="text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950 shrink-0"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <Button
+                  variant="outline"
+                  onClick={addCustomEnvVar}
+                  className="w-full gap-2"
+                  size="sm"
+                >
+                  <Plus className="h-4 w-4" />
+                  Add Custom Variable
+                </Button>
+              </div>
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={() => setStep(1)}
+                  className="gap-2"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </Button>
+                <Button
+                  onClick={() => setStep(3)}
+                  className="flex-1 gap-2"
+                >
+                  Preview
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 3: Preview */}
+        {step === 3 && (
+          <Card>
+            <CardContent className="pt-6 pb-6 space-y-6">
+              <div className="text-center space-y-2">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-zinc-100">
+                  Your docker-compose.yml
+                </h2>
+                <p className="text-gray-500 dark:text-zinc-400 text-sm">
+                  Review and download your generated configuration.
+                </p>
+              </div>
+
+              {/* YAML Preview */}
+              <div className="relative">
+                <pre
+                  className="bg-gray-900 dark:bg-zinc-900 text-green-400 dark:text-green-300 p-4 rounded-lg text-sm font-mono overflow-x-auto whitespace-pre leading-relaxed"
+                  data-testid="yaml-preview"
+                >
+                  {generatedYaml}
+                </pre>
+              </div>
+
+              {/* Action buttons */}
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={handleCopy}
+                  className="flex-1 gap-2"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-4 w-4" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4" />
+                      Copy to Clipboard
+                    </>
+                  )}
+                </Button>
+                <Button onClick={handleDownload} className="flex-1 gap-2">
+                  <Download className="h-4 w-4" />
+                  Download File
+                </Button>
+              </div>
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  onClick={() => setStep(2)}
+                  className="gap-2"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/docker-compose.ts
+++ b/src/lib/docker-compose.ts
@@ -1,0 +1,144 @@
+export interface DockerComposeConfig {
+  /** Host port to map to the Tuis container (default: 6969) */
+  port: number;
+  /** Named volume or host path for data persistence (default: "tuis-data") */
+  volumePath: string;
+  /** Include the MCP server sidecar (default: false) */
+  includeMcp: boolean;
+  /** Environment variable overrides (key-value pairs) */
+  envVars: Record<string, string>;
+  /** Tuis image tag (default: "latest") */
+  imageTag: string;
+}
+
+export const DEFAULT_CONFIG: DockerComposeConfig = {
+  port: 6969,
+  volumePath: "tuis-data",
+  imageTag: "latest",
+  includeMcp: false,
+  envVars: {},
+};
+
+export function generateDockerCompose(
+  partial: Partial<DockerComposeConfig> = {}
+): string {
+  const config: DockerComposeConfig = { ...DEFAULT_CONFIG, ...partial };
+
+  const lines: string[] = [];
+
+  lines.push("services:");
+  lines.push("  tuis:");
+  lines.push(
+    `    image: ghcr.io/heuwels/tuis:\${TUIS_VERSION:-${config.imageTag}}`
+  );
+  lines.push("    container_name: tuis");
+  lines.push("    restart: unless-stopped");
+  lines.push("    ports:");
+  lines.push(`      - "\${WEB_PORT:-${config.port}}:3000"`);
+  lines.push("    volumes:");
+
+  if (isNamedVolume(config.volumePath)) {
+    lines.push(`      - ${config.volumePath}:/app/data`);
+  } else {
+    lines.push(`      - ${config.volumePath}:/app/data`);
+  }
+
+  // Environment variables
+  const envEntries = buildEnvEntries(config);
+  if (envEntries.length > 0) {
+    lines.push("    environment:");
+    for (const entry of envEntries) {
+      lines.push(`      - ${entry}`);
+    }
+  }
+
+  // MCP sidecar
+  if (config.includeMcp) {
+    lines.push("");
+    lines.push("  mcp-server:");
+    lines.push(
+      `    image: ghcr.io/heuwels/tuis:\${TUIS_VERSION:-${config.imageTag}}`
+    );
+    lines.push("    container_name: tuis-mcp");
+    lines.push("    restart: unless-stopped");
+    lines.push('    command: ["node", "mcp-server/dist/index.js"]');
+    lines.push("    environment:");
+    lines.push("      - TUIS_API_URL=http://tuis:3000");
+    lines.push("    depends_on:");
+    lines.push("      - tuis");
+  }
+
+  // Named volumes section
+  const namedVolumes = collectNamedVolumes(config);
+  if (namedVolumes.length > 0) {
+    lines.push("");
+    lines.push("volumes:");
+    for (const vol of namedVolumes) {
+      lines.push(`  ${vol}:`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function buildEnvEntries(config: DockerComposeConfig): string[] {
+  const entries: string[] = [];
+
+  entries.push("NODE_ENV=production");
+
+  // Default optional env vars with shell-variable syntax
+  const defaults: Record<string, string> = {
+    NEXTAUTH_URL: "http://localhost:3000",
+  };
+
+  // Optional env vars that have no default -- only include if user provided them
+  const optionalKeys = [
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "NEXTAUTH_SECRET",
+    "ACTUAL_API_URL",
+  ];
+
+  // Always include NEXTAUTH_URL with its default
+  const nextauthUrl =
+    config.envVars["NEXTAUTH_URL"] || defaults["NEXTAUTH_URL"];
+  entries.push(
+    `NEXTAUTH_URL=\${NEXTAUTH_URL:-${nextauthUrl}}`
+  );
+
+  for (const key of optionalKeys) {
+    if (config.envVars[key]) {
+      entries.push(`${key}=\${${key}:-${config.envVars[key]}}`);
+    } else {
+      entries.push(`${key}=\${${key}}`);
+    }
+  }
+
+  // Any extra env vars the user added
+  for (const [key, value] of Object.entries(config.envVars)) {
+    if (
+      key === "NEXTAUTH_URL" ||
+      optionalKeys.includes(key) ||
+      key === "NODE_ENV"
+    ) {
+      continue;
+    }
+    entries.push(`${key}=${value}`);
+  }
+
+  return entries;
+}
+
+/** A named volume is a simple identifier (no slashes, no dots at start). */
+function isNamedVolume(path: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(path);
+}
+
+function collectNamedVolumes(config: DockerComposeConfig): string[] {
+  const volumes: string[] = [];
+  if (isNamedVolume(config.volumePath)) {
+    volumes.push(config.volumePath);
+  }
+  return volumes;
+}


### PR DESCRIPTION
## Summary
- Adds an interactive Docker Compose wizard at `/setup/docker-wizard` (accessible without auth)
- Multi-step UI: core settings (port, volume, image tag) -> sidecar selection (MCP server) -> environment variables -> YAML preview with copy/download
- Pure generation logic in `src/lib/docker-compose.ts` produces valid docker-compose YAML based on `deploy/docker-compose.yml` conventions
- Follows existing setup wizard patterns (step indicators, Card layout, dark mode support)

Closes #33

## Test plan
- [x] 18 unit tests for YAML generation logic (`src/app/api/__tests__/docker-compose.test.ts`) -- all passing
- [x] 6 E2E tests for wizard navigation, configuration, and output verification (`e2e/docker-wizard.spec.ts`)
- [x] `npm test` -- 77 tests passing (5 files)
- [x] `npm run lint` -- 0 errors (only pre-existing warnings)
- [x] `next build` succeeds with `/setup/docker-wizard` route listed
