### PR TITLE
feat: configurable units (metric/imperial)

### DIFF
--- a/e2e/settings-units.spec.ts
+++ b/e2e/settings-units.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function dismissUserPickerIfVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  const dialog = page.getByRole("dialog");
+  const isVisible = await dialog.isVisible().catch(() => false);
+  if (isVisible) {
+    const heading = dialog.getByRole("heading");
+    const text = await heading.textContent().catch(() => "");
+    if (text === "Who are you?" || text === "Switch User") {
+      const userButton = dialog.locator("button").first();
+      if (await userButton.isVisible().catch(() => false)) {
+        await userButton.click();
+        await expect(dialog).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+  }
+}
+
+test.afterAll(async ({ request }) => {
+  // Reset unit system back to metric after tests
+  await request.put("/api/settings", {
+    data: { key: "unitSystem", value: "metric" },
+  });
+});
+
+test.describe.serial("Unit System Settings", () => {
+  test("should show the unit system card on settings page", async ({
+    page,
+  }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    await expect(
+      page.getByRole("heading", { name: "Unit System" })
+    ).toBeVisible();
+
+    // Should see both toggle buttons
+    await expect(page.getByTestId("unit-metric")).toBeVisible();
+    await expect(page.getByTestId("unit-imperial")).toBeVisible();
+  });
+
+  test("should default to metric", async ({ page }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    // The metric button should be the active (default) variant
+    const metricBtn = page.getByTestId("unit-metric");
+    await expect(metricBtn).toBeVisible();
+  });
+
+  test("should switch to imperial and persist", async ({ page }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    // Click imperial
+    await page.getByTestId("unit-imperial").click();
+
+    // Wait for the save to complete
+    await page.waitForResponse((r) =>
+      r.url().includes("/api/settings") && r.status() === 200
+    );
+
+    // Reload and verify it persists
+    await page.reload();
+    await dismissUserPickerIfVisible(page);
+
+    // The imperial button should now have the "default" variant (active state)
+    // Verify via the API that the setting persisted
+    const res = await page.evaluate(async () => {
+      const r = await fetch("/api/settings");
+      return r.json();
+    });
+    expect(res.unitSystem).toBe("imperial");
+  });
+
+  test("should switch back to metric", async ({ page }) => {
+    await page.goto("/settings");
+    await dismissUserPickerIfVisible(page);
+
+    // Click metric
+    await page.getByTestId("unit-metric").click();
+
+    await page.waitForResponse((r) =>
+      r.url().includes("/api/settings") && r.status() === 200
+    );
+
+    const res = await page.evaluate(async () => {
+      const r = await fetch("/api/settings");
+      return r.json();
+    });
+    expect(res.unitSystem).toBe("metric");
+  });
+
+  test("settings API works directly", async ({ request }) => {
+    // GET should return current settings
+    const getRes = await request.get("/api/settings");
+    expect(getRes.status()).toBe(200);
+
+    // PUT to set imperial
+    const putRes = await request.put("/api/settings", {
+      data: { key: "unitSystem", value: "imperial" },
+    });
+    expect(putRes.status()).toBe(200);
+    const putData = await putRes.json();
+    expect(putData.value).toBe("imperial");
+
+    // GET should now show imperial
+    const getRes2 = await request.get("/api/settings");
+    const data = await getRes2.json();
+    expect(data.unitSystem).toBe("imperial");
+
+    // PUT invalid value should fail
+    const badRes = await request.put("/api/settings", {
+      data: { key: "unitSystem", value: "invalid" },
+    });
+    expect(badRes.status()).toBe(400);
+
+    // Reset to metric
+    await request.put("/api/settings", {
+      data: { key: "unitSystem", value: "metric" },
+    });
+  });
+});

--- a/src/app/api/__tests__/settings.test.ts
+++ b/src/app/api/__tests__/settings.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+// ─── In-memory DB wiring ────────────────────────────────────────────────────
+
+let testDb: ReturnType<typeof drizzle>;
+let sqlite: Database.Database;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+  schema,
+}));
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${url}`, init);
+}
+
+function jsonBody(data: Record<string, unknown>): RequestInit {
+  return {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SETTINGS API
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Settings API", () => {
+  let settingsRoute: typeof import("@/app/api/settings/route");
+
+  beforeEach(async () => {
+    settingsRoute = await import("@/app/api/settings/route");
+  });
+
+  describe("GET /api/settings", () => {
+    it("returns empty object when no settings", async () => {
+      const res = await settingsRoute.GET();
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({});
+    });
+
+    it("returns all settings as key-value pairs", async () => {
+      // Insert settings directly
+      sqlite.exec(
+        `INSERT INTO settings (key, value) VALUES ('unitSystem', 'metric')`
+      );
+      sqlite.exec(
+        `INSERT INTO settings (key, value) VALUES ('theme', 'dark')`
+      );
+
+      const res = await settingsRoute.GET();
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.unitSystem).toBe("metric");
+      expect(data.theme).toBe("dark");
+    });
+  });
+
+  describe("PUT /api/settings", () => {
+    it("creates a new setting", async () => {
+      const req = makeRequest(
+        "/api/settings",
+        jsonBody({ key: "unitSystem", value: "metric" })
+      );
+      const res = await settingsRoute.PUT(req);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.key).toBe("unitSystem");
+      expect(data.value).toBe("metric");
+
+      // Verify it's persisted
+      const getRes = await settingsRoute.GET();
+      const settings = await getRes.json();
+      expect(settings.unitSystem).toBe("metric");
+    });
+
+    it("updates an existing setting", async () => {
+      // Create first
+      const req1 = makeRequest(
+        "/api/settings",
+        jsonBody({ key: "unitSystem", value: "metric" })
+      );
+      await settingsRoute.PUT(req1);
+
+      // Update
+      const req2 = makeRequest(
+        "/api/settings",
+        jsonBody({ key: "unitSystem", value: "imperial" })
+      );
+      const res = await settingsRoute.PUT(req2);
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.value).toBe("imperial");
+
+      // Verify it's updated
+      const getRes = await settingsRoute.GET();
+      const settings = await getRes.json();
+      expect(settings.unitSystem).toBe("imperial");
+    });
+
+    it("rejects missing key", async () => {
+      const req = makeRequest(
+        "/api/settings",
+        jsonBody({ value: "metric" })
+      );
+      const res = await settingsRoute.PUT(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects missing value", async () => {
+      const req = makeRequest(
+        "/api/settings",
+        jsonBody({ key: "unitSystem" })
+      );
+      const res = await settingsRoute.PUT(req);
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects invalid unitSystem value", async () => {
+      const req = makeRequest(
+        "/api/settings",
+        jsonBody({ key: "unitSystem", value: "invalid" })
+      );
+      const res = await settingsRoute.PUT(req);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("metric");
+    });
+
+    it("accepts valid unitSystem values", async () => {
+      for (const value of ["metric", "imperial"]) {
+        const req = makeRequest(
+          "/api/settings",
+          jsonBody({ key: "unitSystem", value })
+        );
+        const res = await settingsRoute.PUT(req);
+        expect(res.status).toBe(200);
+      }
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// UNIT CONVERSION LOGIC
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Unit Conversions", () => {
+  let units: typeof import("@/lib/units");
+
+  beforeEach(async () => {
+    units = await import("@/lib/units");
+  });
+
+  describe("distance", () => {
+    it("converts km to miles", () => {
+      expect(units.kmToMiles(100)).toBeCloseTo(62.137, 2);
+    });
+
+    it("converts miles to km", () => {
+      expect(units.milesToKm(62.137)).toBeCloseTo(100, 0);
+    });
+
+    it("formats distance in metric", () => {
+      expect(units.formatDistance(1500, "metric")).toBe("1,500 km");
+    });
+
+    it("formats distance in imperial", () => {
+      expect(units.formatDistance(100, "imperial")).toBe("62 mi");
+    });
+  });
+
+  describe("volume", () => {
+    it("converts litres to gallons", () => {
+      expect(units.litresToGallons(3.785)).toBeCloseTo(1.0, 1);
+    });
+
+    it("converts gallons to litres", () => {
+      expect(units.gallonsToLitres(1.0)).toBeCloseTo(3.785, 2);
+    });
+
+    it("formats volume in metric", () => {
+      expect(units.formatVolume(45.5, "metric")).toBe("45.50 L");
+    });
+
+    it("formats volume in imperial", () => {
+      expect(units.formatVolume(45.5, "imperial")).toBe("12.02 gal");
+    });
+  });
+
+  describe("weight", () => {
+    it("converts kg to pounds", () => {
+      expect(units.kgToPounds(1)).toBeCloseTo(2.205, 2);
+    });
+
+    it("converts grams to ounces", () => {
+      expect(units.gramsToOunces(100)).toBeCloseTo(3.527, 2);
+    });
+
+    it("formats weight in grams metric", () => {
+      expect(units.formatWeightG(500, "metric")).toBe("500 g");
+    });
+
+    it("formats weight in grams imperial (oz)", () => {
+      expect(units.formatWeightG(100, "imperial")).toBe("3.5 oz");
+    });
+
+    it("formats large weight in grams as kg", () => {
+      expect(units.formatWeightG(1500, "metric")).toBe("1.5 kg");
+    });
+
+    it("formats large weight in grams as lb", () => {
+      expect(units.formatWeightG(500, "imperial")).toBe("1.1 lb");
+    });
+  });
+
+  describe("temperature", () => {
+    it("converts 0C to 32F", () => {
+      expect(units.celsiusToFahrenheit(0)).toBe(32);
+    });
+
+    it("converts 100C to 212F", () => {
+      expect(units.celsiusToFahrenheit(100)).toBe(212);
+    });
+
+    it("converts 32F to 0C", () => {
+      expect(units.fahrenheitToCelsius(32)).toBe(0);
+    });
+
+    it("formats temperature metric", () => {
+      expect(units.formatTemperature(20, "metric")).toBe("20\u00B0C");
+    });
+
+    it("formats temperature imperial", () => {
+      expect(units.formatTemperature(20, "imperial")).toBe("68\u00B0F");
+    });
+  });
+
+  describe("fuel economy", () => {
+    it("formats L/100km in metric", () => {
+      expect(units.formatFuelEconomy(8.5, "metric")).toBe("8.5 L/100km");
+    });
+
+    it("formats MPG in imperial", () => {
+      // 8.5 L/100km = ~27.7 MPG
+      expect(units.formatFuelEconomy(8.5, "imperial")).toBe("27.7 MPG");
+    });
+  });
+
+  describe("cost per volume", () => {
+    it("formats cost per litre in metric", () => {
+      expect(units.formatCostPerVolume(1.5, "metric")).toBe("$1.500/L");
+    });
+
+    it("formats cost per gallon in imperial", () => {
+      // $1.50/L = ~$5.68/gal
+      expect(units.formatCostPerVolume(1.5, "imperial")).toBe("$5.678/gal");
+    });
+  });
+
+  describe("cost per distance", () => {
+    it("formats cost per km in metric", () => {
+      expect(units.formatCostPerDistance(0.15, "metric")).toBe("$0.15/km");
+    });
+
+    it("formats cost per mile in imperial", () => {
+      // $0.15/km = ~$0.24/mi
+      expect(units.formatCostPerDistance(0.15, "imperial")).toBe("$0.24/mi");
+    });
+  });
+
+  describe("unit labels", () => {
+    it("returns metric labels", () => {
+      const labels = units.getUnitLabels("metric");
+      expect(labels.km).toBe("km");
+      expect(labels.litresShort).toBe("L");
+      expect(labels.kg).toBe("kg");
+    });
+
+    it("returns imperial labels", () => {
+      const labels = units.getUnitLabels("imperial");
+      expect(labels.km).toBe("mi");
+      expect(labels.litresShort).toBe("gal");
+      expect(labels.kg).toBe("lb");
+    });
+  });
+});

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { settings } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const rows = await db.select().from(settings);
+    const result: Record<string, string> = {};
+    for (const row of rows) {
+      result[row.key] = row.value;
+    }
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error fetching settings:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch settings" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const body = await request.json();
+    const { key, value } = body;
+
+    if (!key || typeof key !== "string") {
+      return NextResponse.json(
+        { error: "key is required and must be a string" },
+        { status: 400 }
+      );
+    }
+
+    if (value === undefined || value === null || typeof value !== "string") {
+      return NextResponse.json(
+        { error: "value is required and must be a string" },
+        { status: 400 }
+      );
+    }
+
+    // Validate known settings
+    if (key === "unitSystem" && !["metric", "imperial"].includes(value)) {
+      return NextResponse.json(
+        { error: "unitSystem must be 'metric' or 'imperial'" },
+        { status: 400 }
+      );
+    }
+
+    // Upsert the setting
+    const existing = await db
+      .select()
+      .from(settings)
+      .where(eq(settings.key, key))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .update(settings)
+        .set({ value, updatedAt: new Date().toISOString() })
+        .where(eq(settings.key, key));
+    } else {
+      await db.insert(settings).values({
+        key,
+        value,
+        updatedAt: new Date().toISOString(),
+      });
+    }
+
+    return NextResponse.json({ key, value });
+  } catch (error) {
+    console.error("Error updating setting:", error);
+    return NextResponse.json(
+      { error: "Failed to update setting" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -15,6 +15,7 @@ import { User } from "@/types";
 import { Plus, Pencil, Trash2, Users } from "lucide-react";
 import { GoogleCalendarCard } from "@/components/settings/GoogleCalendarCard";
 import { PersonalAccessTokensCard } from "@/components/settings/PersonalAccessTokensCard";
+import { UnitSystemCard } from "@/components/settings/UnitSystemCard";
 import { AppLayout } from "@/components/layout/AppLayout";
 
 const COLORS = [
@@ -112,6 +113,7 @@ export default function SettingsPage() {
   return (
     <AppLayout title="Settings">
       <div className="space-y-6 max-w-2xl">
+        <UnitSystemCard />
         <GoogleCalendarCard />
         <PersonalAccessTokensCard />
 

--- a/src/components/settings/UnitSystemCard.tsx
+++ b/src/components/settings/UnitSystemCard.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Ruler } from "lucide-react";
+import type { UnitSystem } from "@/lib/units";
+
+export function UnitSystemCard() {
+  const [unitSystem, setUnitSystem] = useState<UnitSystem>("metric");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/settings")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.unitSystem === "metric" || data.unitSystem === "imperial") {
+          setUnitSystem(data.unitSystem);
+        }
+      })
+      .catch(console.error)
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  const handleToggle = async (system: UnitSystem) => {
+    if (system === unitSystem) return;
+    setIsSaving(true);
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "unitSystem", value: system }),
+      });
+      if (response.ok) {
+        setUnitSystem(system);
+      }
+    } catch (error) {
+      console.error("Error saving unit system:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Ruler className="h-5 w-5" />
+          Unit System
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <p className="text-muted-foreground text-center py-4">Loading...</p>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Choose your preferred unit system for distances, volumes, and
+              weights. Data is stored in metric and converted for display.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant={unitSystem === "metric" ? "default" : "outline"}
+                onClick={() => handleToggle("metric")}
+                disabled={isSaving}
+                className="flex-1"
+                data-testid="unit-metric"
+              >
+                Metric
+                <span className="ml-2 text-xs opacity-70">km, L, kg</span>
+              </Button>
+              <Button
+                variant={unitSystem === "imperial" ? "default" : "outline"}
+                onClick={() => handleToggle("imperial")}
+                disabled={isSaving}
+                className="flex-1"
+                data-testid="unit-imperial"
+              >
+                Imperial
+                <span className="ml-2 text-xs opacity-70">mi, gal, lb</span>
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/vehicles/FuelAnalytics.tsx
+++ b/src/components/vehicles/FuelAnalytics.tsx
@@ -11,6 +11,14 @@ import {
   Gauge,
 } from "lucide-react";
 import { format, parse } from "date-fns";
+import { useUnitSystem } from "@/lib/useUnitSystem";
+import {
+  formatDistance,
+  formatCostPerVolume,
+  formatFuelEconomy,
+  formatCostPerDistance,
+  getUnitLabels,
+} from "@/lib/units";
 
 interface MonthlyData {
   month: string;
@@ -129,7 +137,7 @@ function BarChart({
   );
 }
 
-function MultiLineChart({ data }: { data: MonthlyData[] }) {
+function MultiLineChart({ data, labels }: { data: MonthlyData[]; labels: import("@/lib/units").UnitLabels }) {
   if (data.length < 2) return null;
 
   const metrics = [
@@ -138,14 +146,14 @@ function MultiLineChart({ data }: { data: MonthlyData[] }) {
       label: "Fuel Price",
       color: "text-red-500",
       dotColor: "bg-red-500",
-      format: (v: number) => `$${v.toFixed(3)}/L`,
+      format: (v: number) => `$${v.toFixed(3)}/${labels.litresShort}`,
     },
     {
       key: "fuelEconomy" as const,
       label: "Economy",
       color: "text-blue-500",
       dotColor: "bg-blue-500",
-      format: (v: number) => `${v.toFixed(1)} L/100km`,
+      format: (v: number) => `${v.toFixed(1)} ${labels.per100km}`,
     },
     {
       key: "totalSpend" as const,
@@ -280,6 +288,8 @@ function MultiLineChart({ data }: { data: MonthlyData[] }) {
 export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
   const [analytics, setAnalytics] = useState<FuelAnalyticsData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const { unitSystem } = useUnitSystem();
+  const labels = getUnitLabels(unitSystem);
 
   useEffect(() => {
     let cancelled = false;
@@ -325,10 +335,10 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
             <MetricCard
               icon={DollarSign}
               label="Avg Price (3 mo)"
-              value={`$${keyMetrics.rolling3MonthPrice.toFixed(3)}/L`}
+              value={formatCostPerVolume(keyMetrics.rolling3MonthPrice, unitSystem)}
               subtitle={
                 keyMetrics.allTimePrice
-                  ? `All-time: $${keyMetrics.allTimePrice.toFixed(3)}/L`
+                  ? `All-time: ${formatCostPerVolume(keyMetrics.allTimePrice, unitSystem)}`
                   : undefined
               }
               bgClass="bg-red-50 dark:bg-red-950/30"
@@ -339,7 +349,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
             <MetricCard
               icon={MapPin}
               label="Avg Monthly Distance"
-              value={`${Math.round(keyMetrics.avgMonthlyDistance).toLocaleString()} km`}
+              value={formatDistance(keyMetrics.avgMonthlyDistance, unitSystem)}
               bgClass="bg-blue-50 dark:bg-blue-950/30"
               textClass="text-blue-700 dark:text-blue-400"
             />
@@ -347,11 +357,11 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
           {keyMetrics.recentCostPerKm !== null && (
             <MetricCard
               icon={Gauge}
-              label="Cost/km (3 mo)"
-              value={`$${keyMetrics.recentCostPerKm.toFixed(2)}/km`}
+              label={`Cost/${labels.km} (3 mo)`}
+              value={formatCostPerDistance(keyMetrics.recentCostPerKm, unitSystem)}
               subtitle={
                 keyMetrics.priorCostPerKm
-                  ? `Prior 3 mo: $${keyMetrics.priorCostPerKm.toFixed(2)}/km`
+                  ? `Prior 3 mo: ${formatCostPerDistance(keyMetrics.priorCostPerKm, unitSystem)}`
                   : undefined
               }
               bgClass="bg-green-50 dark:bg-green-950/30"
@@ -366,7 +376,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
               <MetricCard
                 icon={Fuel}
                 label="Latest Economy"
-                value={`${latest.fuelEconomy!.toFixed(1)} L/100km`}
+                value={formatFuelEconomy(latest.fuelEconomy!, unitSystem)}
                 bgClass="bg-amber-50 dark:bg-amber-950/30"
                 textClass="text-amber-700 dark:text-amber-400"
               />
@@ -462,9 +472,9 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
         <BarChart
           data={chartData}
           getValue={(d) => d.avgPricePerLitre}
-          formatValue={(v) => `$${v.toFixed(3)}/L`}
+          formatValue={(v) => `$${v.toFixed(3)}/${labels.litresShort}`}
           barColor="bg-red-400"
-          label="Average Fuel Price ($/L)"
+          label={`Average Fuel Price ($/${labels.litresShort})`}
         />
       </div>
 
@@ -473,7 +483,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
         <BarChart
           data={chartData}
           getValue={(d) => d.distanceKm}
-          formatValue={(v) => `${v.toLocaleString()} km`}
+          formatValue={(v) => formatDistance(v, unitSystem)}
           barColor="bg-blue-500"
           label="Distance per Month"
         />
@@ -481,7 +491,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
 
       {/* Multi-line overlay */}
       <div className="p-3 bg-gray-50 dark:bg-zinc-800 rounded-lg">
-        <MultiLineChart data={chartData} />
+        <MultiLineChart data={chartData} labels={labels} />
       </div>
     </div>
   );

--- a/src/components/vehicles/VehicleCard.tsx
+++ b/src/components/vehicles/VehicleCard.tsx
@@ -5,6 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import { Vehicle } from "@/types";
 import { Car, Gauge, Calendar, AlertTriangle } from "lucide-react";
 import { format, parseISO, isPast, isBefore, addDays } from "date-fns";
+import { useUnitSystem } from "@/lib/useUnitSystem";
+import { formatDistance } from "@/lib/units";
 
 interface VehicleCardProps {
   vehicle: Vehicle;
@@ -44,6 +46,7 @@ function RegoStatus({ expiryDate }: { expiryDate: string | null }) {
 }
 
 export function VehicleCard({ vehicle, onClick }: VehicleCardProps) {
+  const { unitSystem } = useUnitSystem();
   const subtitle = [vehicle.make, vehicle.model, vehicle.year]
     .filter(Boolean)
     .join(" ");
@@ -88,7 +91,7 @@ export function VehicleCard({ vehicle, onClick }: VehicleCardProps) {
           {vehicle.currentOdometer && (
             <span className="flex items-center gap-1">
               <Gauge className="h-4 w-4" />
-              {vehicle.currentOdometer.toLocaleString()} km
+              {formatDistance(vehicle.currentOdometer, unitSystem)}
             </span>
           )}
         </div>

--- a/src/components/vehicles/VehicleDetail.tsx
+++ b/src/components/vehicles/VehicleDetail.tsx
@@ -44,6 +44,15 @@ import {
 } from "lucide-react";
 import { format, parseISO, isPast, isBefore, addDays } from "date-fns";
 import { cn } from "@/lib/utils";
+import { useUnitSystem } from "@/lib/useUnitSystem";
+import {
+  formatDistance,
+  formatVolume,
+  formatCostPerVolume,
+  formatFuelEconomy,
+  formatCostPerDistance,
+  getUnitLabels,
+} from "@/lib/units";
 import { FuelAnalytics } from "./FuelAnalytics";
 
 type TabId = "overview" | "services" | "fuel" | "costs" | "analytics";
@@ -420,6 +429,8 @@ export function VehicleDetail({
   const [costSummary, setCostSummary] = useState<VehicleCostSummary | null>(
     null
   );
+  const { unitSystem } = useUnitSystem();
+  const labels = getUnitLabels(unitSystem);
 
   useEffect(() => {
     if (vehicle && activeTab === "costs") {
@@ -513,7 +524,7 @@ export function VehicleDetail({
                     <p className="text-xs text-muted-foreground">Odometer</p>
                     <p className="font-medium flex items-center gap-1">
                       <Gauge className="h-4 w-4" />
-                      {vehicle.currentOdometer.toLocaleString()} km
+                      {formatDistance(vehicle.currentOdometer, unitSystem)}
                     </p>
                   </div>
                 )}
@@ -554,10 +565,10 @@ export function VehicleDetail({
                 {vehicle.warrantyExpiryKm && (
                   <div className="flex items-center justify-between p-2 bg-gray-50 rounded-lg">
                     <span className="text-sm text-muted-foreground">
-                      Warranty km limit
+                      Warranty {labels.km} limit
                     </span>
                     <span className="text-sm font-medium">
-                      {vehicle.warrantyExpiryKm.toLocaleString()} km
+                      {formatDistance(vehicle.warrantyExpiryKm, unitSystem)}
                     </span>
                   </div>
                 )}
@@ -617,7 +628,7 @@ export function VehicleDetail({
                           </div>
                           {service.odometer && (
                             <p className="text-xs text-muted-foreground mt-1">
-                              {service.odometer.toLocaleString()} km
+                              {formatDistance(service.odometer, unitSystem)}
                             </p>
                           )}
                           {service.notes && (
@@ -666,10 +677,10 @@ export function VehicleDetail({
                             {format(parseISO(log.date), "d MMM yyyy")}
                           </p>
                           <div className="flex flex-wrap gap-3 mt-1 text-muted-foreground">
-                            <span>{log.odometer.toLocaleString()} km</span>
-                            <span>{log.litres.toFixed(2)} L</span>
+                            <span>{formatDistance(log.odometer, unitSystem)}</span>
+                            <span>{formatVolume(log.litres, unitSystem)}</span>
                             {log.costPerLitre && (
-                              <span>${log.costPerLitre.toFixed(3)}/L</span>
+                              <span>{formatCostPerVolume(log.costPerLitre, unitSystem)}</span>
                             )}
                             {log.station && <span>{log.station}</span>}
                           </div>
@@ -738,7 +749,7 @@ export function VehicleDetail({
                         Distance Tracked
                       </p>
                       <p className="text-lg font-semibold">
-                        {costSummary.totalKmTracked.toLocaleString()} km
+                        {formatDistance(costSummary.totalKmTracked, unitSystem)}
                       </p>
                     </div>
                   </div>
@@ -748,10 +759,10 @@ export function VehicleDetail({
                         <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                           <div className="flex items-center gap-2">
                             <TrendingUp className="h-4 w-4 text-muted-foreground" />
-                            <span className="text-sm">Cost per km</span>
+                            <span className="text-sm">Cost per {labels.km}</span>
                           </div>
                           <span className="font-medium">
-                            ${costSummary.costPerKm.toFixed(2)}/km
+                            {formatCostPerDistance(costSummary.costPerKm, unitSystem)}
                           </span>
                         </div>
                       )}
@@ -764,7 +775,7 @@ export function VehicleDetail({
                             </span>
                           </div>
                           <span className="font-medium">
-                            {costSummary.avgFuelConsumption.toFixed(1)} L/100km
+                            {formatFuelEconomy(costSummary.avgFuelConsumption, unitSystem)}
                           </span>
                         </div>
                       )}
@@ -777,7 +788,7 @@ export function VehicleDetail({
                             </span>
                           </div>
                           <span className="font-medium">
-                            {costSummary.totalFuelLitres.toFixed(1)} L
+                            {formatVolume(costSummary.totalFuelLitres, unitSystem)}
                           </span>
                         </div>
                       )}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -262,6 +262,12 @@ function initDb(): BetterSQLite3Database<typeof schema> {
       expires_at TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
+
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
   `);
 
   // Add new columns if they don't exist (migrations for existing databases)

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -295,5 +295,13 @@ export const personalAccessTokens = sqliteTable("personal_access_tokens", {
 
 export type FuelLog = typeof fuelLogs.$inferSelect;
 export type NewFuelLog = typeof fuelLogs.$inferInsert;
+export const settings = sqliteTable("settings", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+});
+
 export type PersonalAccessToken = typeof personalAccessTokens.$inferSelect;
 export type NewPersonalAccessToken = typeof personalAccessTokens.$inferInsert;
+export type Setting = typeof settings.$inferSelect;
+export type NewSetting = typeof settings.$inferInsert;

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,247 @@
+// Unit system types and conversion utilities
+// Data is always stored in metric internally; imperial is display-only.
+
+export type UnitSystem = "metric" | "imperial";
+
+// --- Conversion factors (metric -> imperial) ---
+
+const KM_TO_MILES = 0.621371;
+const LITRES_TO_GALLONS = 0.264172;
+const KG_TO_POUNDS = 2.20462;
+const G_TO_OUNCES = 0.035274;
+const ML_TO_FL_OZ = 0.033814;
+const CELSIUS_TO_FAHRENHEIT = (c: number) => c * 9 / 5 + 32;
+const FAHRENHEIT_TO_CELSIUS = (f: number) => (f - 32) * 5 / 9;
+
+// --- Conversion functions ---
+
+export function kmToMiles(km: number): number {
+  return km * KM_TO_MILES;
+}
+
+export function milesToKm(miles: number): number {
+  return miles / KM_TO_MILES;
+}
+
+export function litresToGallons(litres: number): number {
+  return litres * LITRES_TO_GALLONS;
+}
+
+export function gallonsToLitres(gallons: number): number {
+  return gallons / LITRES_TO_GALLONS;
+}
+
+export function kgToPounds(kg: number): number {
+  return kg * KG_TO_POUNDS;
+}
+
+export function poundsToKg(pounds: number): number {
+  return pounds / KG_TO_POUNDS;
+}
+
+export function gramsToOunces(grams: number): number {
+  return grams * G_TO_OUNCES;
+}
+
+export function ouncesToGrams(ounces: number): number {
+  return ounces / G_TO_OUNCES;
+}
+
+export function mlToFlOz(ml: number): number {
+  return ml * ML_TO_FL_OZ;
+}
+
+export function flOzToMl(flOz: number): number {
+  return flOz / ML_TO_FL_OZ;
+}
+
+export function celsiusToFahrenheit(c: number): number {
+  return CELSIUS_TO_FAHRENHEIT(c);
+}
+
+export function fahrenheitToCelsius(f: number): number {
+  return FAHRENHEIT_TO_CELSIUS(f);
+}
+
+// --- Unit label maps ---
+
+export interface UnitLabels {
+  km: string;
+  litres: string;
+  litresShort: string;
+  gallonsShort: string;
+  perLitre: string;
+  per100km: string;
+  kg: string;
+  g: string;
+  mL: string;
+  L: string;
+  celsius: string;
+}
+
+const METRIC_LABELS: UnitLabels = {
+  km: "km",
+  litres: "litres",
+  litresShort: "L",
+  gallonsShort: "gal",
+  perLitre: "/L",
+  per100km: "L/100km",
+  kg: "kg",
+  g: "g",
+  mL: "mL",
+  L: "L",
+  celsius: "\u00B0C",
+};
+
+const IMPERIAL_LABELS: UnitLabels = {
+  km: "mi",
+  litres: "gallons",
+  litresShort: "gal",
+  gallonsShort: "gal",
+  perLitre: "/gal",
+  per100km: "MPG",
+  kg: "lb",
+  g: "oz",
+  mL: "fl oz",
+  L: "gal",
+  celsius: "\u00B0F",
+};
+
+export function getUnitLabels(system: UnitSystem): UnitLabels {
+  return system === "imperial" ? IMPERIAL_LABELS : METRIC_LABELS;
+}
+
+// --- Display formatters ---
+
+/** Format a distance value for display */
+export function formatDistance(km: number, system: UnitSystem): string {
+  if (system === "imperial") {
+    return `${kmToMiles(km).toLocaleString(undefined, { maximumFractionDigits: 0 })} mi`;
+  }
+  return `${km.toLocaleString()} km`;
+}
+
+/** Format a volume value (litres stored internally) for display */
+export function formatVolume(litres: number, system: UnitSystem): string {
+  if (system === "imperial") {
+    return `${litresToGallons(litres).toFixed(2)} gal`;
+  }
+  return `${litres.toFixed(2)} L`;
+}
+
+/** Format cost per litre for display */
+export function formatCostPerVolume(
+  costPerLitre: number,
+  system: UnitSystem
+): string {
+  if (system === "imperial") {
+    // Convert $/L to $/gal: multiply by litres-per-gallon
+    const costPerGallon = costPerLitre / LITRES_TO_GALLONS;
+    return `$${costPerGallon.toFixed(3)}/gal`;
+  }
+  return `$${costPerLitre.toFixed(3)}/L`;
+}
+
+/** Format fuel economy for display.
+ *  Metric: L/100km (lower is better)
+ *  Imperial: MPG (higher is better) */
+export function formatFuelEconomy(
+  lPer100km: number,
+  system: UnitSystem
+): string {
+  if (system === "imperial") {
+    // L/100km -> MPG: 235.215 / L_per_100km
+    const mpg = lPer100km > 0 ? 235.215 / lPer100km : 0;
+    return `${mpg.toFixed(1)} MPG`;
+  }
+  return `${lPer100km.toFixed(1)} L/100km`;
+}
+
+/** Format cost per distance for display */
+export function formatCostPerDistance(
+  costPerKm: number,
+  system: UnitSystem
+): string {
+  if (system === "imperial") {
+    const costPerMile = costPerKm / KM_TO_MILES;
+    return `$${costPerMile.toFixed(2)}/mi`;
+  }
+  return `$${costPerKm.toFixed(2)}/km`;
+}
+
+/** Format a weight in grams for display */
+export function formatWeightG(grams: number, system: UnitSystem): string {
+  if (system === "imperial") {
+    const oz = gramsToOunces(grams);
+    if (oz >= 16) {
+      const lb = oz / 16;
+      return `${lb.toFixed(1)} lb`;
+    }
+    return `${oz.toFixed(1)} oz`;
+  }
+  if (grams >= 1000) {
+    return `${(grams / 1000).toFixed(1)} kg`;
+  }
+  return `${grams.toFixed(0)} g`;
+}
+
+/** Format a weight in kg for display */
+export function formatWeightKg(kg: number, system: UnitSystem): string {
+  if (system === "imperial") {
+    return `${kgToPounds(kg).toFixed(1)} lb`;
+  }
+  return `${kg.toFixed(1)} kg`;
+}
+
+/** Format a volume in mL for display */
+export function formatVolumeMl(ml: number, system: UnitSystem): string {
+  if (system === "imperial") {
+    const flOz = mlToFlOz(ml);
+    if (flOz >= 128) {
+      return `${(flOz / 128).toFixed(2)} gal`;
+    }
+    if (flOz >= 8) {
+      return `${(flOz / 8).toFixed(1)} cups`;
+    }
+    return `${flOz.toFixed(1)} fl oz`;
+  }
+  if (ml >= 1000) {
+    return `${(ml / 1000).toFixed(2)} L`;
+  }
+  return `${ml.toFixed(0)} mL`;
+}
+
+/** Format temperature for display */
+export function formatTemperature(
+  celsius: number,
+  system: UnitSystem
+): string {
+  if (system === "imperial") {
+    return `${celsiusToFahrenheit(celsius).toFixed(0)}\u00B0F`;
+  }
+  return `${celsius.toFixed(0)}\u00B0C`;
+}
+
+// --- Unit categories for reference ---
+
+export const UNIT_CATEGORIES = {
+  distance: {
+    metric: ["km", "m"],
+    imperial: ["mi", "ft", "yd"],
+  },
+  weight: {
+    metric: ["g", "kg"],
+    imperial: ["oz", "lb"],
+  },
+  volume: {
+    metric: ["mL", "L"],
+    imperial: ["fl oz", "cup", "pt", "qt", "gal"],
+  },
+  temperature: {
+    metric: ["\u00B0C"],
+    imperial: ["\u00B0F"],
+  },
+} as const;
+
+// Default unit system
+export const DEFAULT_UNIT_SYSTEM: UnitSystem = "metric";

--- a/src/lib/useUnitSystem.ts
+++ b/src/lib/useUnitSystem.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { UnitSystem } from "./units";
+import { DEFAULT_UNIT_SYSTEM } from "./units";
+
+/**
+ * Hook to fetch the user's preferred unit system from the settings API.
+ * Returns the unit system and a loading state.
+ */
+export function useUnitSystem(): {
+  unitSystem: UnitSystem;
+  isLoading: boolean;
+} {
+  const [unitSystem, setUnitSystem] =
+    useState<UnitSystem>(DEFAULT_UNIT_SYSTEM);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/settings")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.unitSystem === "metric" || data.unitSystem === "imperial") {
+          setUnitSystem(data.unitSystem);
+        }
+      })
+      .catch(console.error)
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  return { unitSystem, isLoading };
+}


### PR DESCRIPTION
## Summary
- Add `settings` table (key-value store) with GET/PUT API at `/api/settings`
- Add unit conversion library (`src/lib/units.ts`) with functions for distance, volume, weight, temperature, fuel economy, and cost formatting between metric and imperial
- Add `useUnitSystem` hook and `UnitSystemCard` toggle on the Settings page
- Wire unit-aware display into vehicle detail (odometer, fuel logs, costs tab, analytics charts) so values show in km/mi, L/gal, L/100km/MPG, $/L vs $/gal, etc.
- Data is always stored in metric internally; conversions happen on display only
- Forms remain in metric to avoid data corruption

**Note:** Recipe ingredient display conversion is not yet wired (follow-up).

## Test plan
- [x] 35 new unit tests covering settings API CRUD, validation, and all unit conversion functions (distance, volume, weight, temperature, fuel economy, cost formatting)
- [x] E2E test (`e2e/settings-units.spec.ts`) verifying the settings card renders, toggle persists across reload, and API validation rejects invalid values
- [ ] Manual: Go to Settings, toggle Imperial, open a vehicle detail -- odometer, fuel logs, and cost metrics should show in miles/gallons/MPG
- [ ] Manual: Toggle back to Metric, verify labels revert to km/L/L/100km

Closes #20

Generated with [Claude Code](https://claude.com/claude-code)
