### PR TITLE
Add expense summary dashboards

### DIFF
--- a/e2e/expenses.spec.ts
+++ b/e2e/expenses.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect, Page } from "@playwright/test";
+
+async function dismissUserPickerIfVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  const dialog = page.getByRole("dialog");
+  const isVisible = await dialog.isVisible().catch(() => false);
+  if (isVisible) {
+    const heading = dialog.getByRole("heading");
+    const text = await heading.textContent().catch(() => "");
+    if (text === "Who are you?" || text === "Switch User") {
+      const userButton = dialog.locator("button").first();
+      if (await userButton.isVisible().catch(() => false)) {
+        await userButton.click();
+        await expect(dialog).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+  }
+}
+
+test.describe("Expense Summary", () => {
+  test.describe.serial("Expenses page", () => {
+    test("should navigate to expenses page", async ({ page }) => {
+      await page.goto("/stats/expenses");
+      await dismissUserPickerIfVisible(page);
+
+      await expect(
+        page.getByRole("heading", { name: "Expenses" }).first()
+      ).toBeVisible();
+
+      // Wait for loading to finish
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+    });
+
+    test("should display spending total and period selector", async ({
+      page,
+    }) => {
+      await page.goto("/stats/expenses");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Period selector buttons should be visible
+      await expect(page.getByRole("button", { name: "Monthly" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Yearly" })).toBeVisible();
+
+      // Total spending label should be visible
+      await expect(page.getByText("Total spending").first()).toBeVisible();
+    });
+
+    test("should switch between monthly and yearly view", async ({ page }) => {
+      await page.goto("/stats/expenses");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Click Yearly button
+      await page.getByRole("button", { name: "Yearly" }).click();
+
+      // Wait for data to reload
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Should now show yearly view label
+      await expect(page.getByText("yearly view").first()).toBeVisible();
+
+      // Switch back to Monthly
+      await page.getByRole("button", { name: "Monthly" }).click();
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      await expect(page.getByText("monthly view").first()).toBeVisible();
+    });
+
+    test("should show empty state or data sections", async ({ page }) => {
+      await page.goto("/stats/expenses");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Should show either category data or an empty-state message
+      const hasCategories = await page
+        .getByText("Maintenance")
+        .first()
+        .isVisible()
+        .catch(() => false);
+      const hasEmptyState = await page
+        .getByText("No expense data recorded yet")
+        .isVisible()
+        .catch(() => false);
+      const hasNoExpenses = await page
+        .getByText("No expenses this month")
+        .isVisible()
+        .catch(() => false);
+
+      // At least one of these should be true
+      expect(hasCategories || hasEmptyState || hasNoExpenses).toBeTruthy();
+    });
+
+    test("should show vendor and vehicle sections", async ({ page }) => {
+      await page.goto("/stats/expenses");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Both section headings should be visible
+      await expect(page.getByText("Top Vendors").first()).toBeVisible();
+      await expect(page.getByText("Vehicle Costs").first()).toBeVisible();
+    });
+
+    test("should have link back to stats", async ({ page }) => {
+      await page.goto("/stats/expenses");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading expenses...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      const backLink = page.getByRole("link", { name: "Back to Statistics" });
+      await expect(backLink).toBeVisible();
+      await backLink.click();
+
+      // Should navigate to stats page
+      await expect(page).toHaveURL(/\/stats$/);
+    });
+  });
+
+  test.describe.serial("Expenses on stats page", () => {
+    test("should have expense summary link on stats page", async ({ page }) => {
+      await page.goto("/stats");
+      await dismissUserPickerIfVisible(page);
+
+      // Should have a link to the expense summary
+      const expenseLink = page.getByRole("link", { name: /Expense Summary/ });
+      await expect(expenseLink).toBeVisible({ timeout: 10000 });
+
+      await expenseLink.click();
+      await expect(page).toHaveURL(/\/stats\/expenses/);
+    });
+  });
+
+  test.describe.serial("Expense widget on dashboard", () => {
+    test("should show expense widget on dashboard", async ({ page }) => {
+      await page.goto("/");
+      await dismissUserPickerIfVisible(page);
+
+      // The expense widget should be visible
+      await expect(
+        page.getByText("Spending This Month").first()
+      ).toBeVisible({ timeout: 10000 });
+    });
+
+    test("should link to expenses page from widget", async ({ page }) => {
+      await page.goto("/");
+      await dismissUserPickerIfVisible(page);
+
+      // Click on the widget
+      const widget = page.getByText("Spending This Month").first();
+      await expect(widget).toBeVisible({ timeout: 10000 });
+      await widget.click();
+
+      // Should navigate to expenses page
+      await expect(page).toHaveURL(/\/stats\/expenses/);
+    });
+  });
+});

--- a/src/app/api/__tests__/expenses.test.ts
+++ b/src/app/api/__tests__/expenses.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+// ─── In-memory DB wiring ────────────────────────────────────────────────────
+
+let testDb: ReturnType<typeof drizzle>;
+let sqlite: Database.Database;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+  schema,
+}));
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      color TEXT NOT NULL DEFAULT '#3b82f6',
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      area TEXT NOT NULL,
+      frequency TEXT NOT NULL,
+      assigned_day TEXT,
+      season TEXT,
+      notes TEXT,
+      extended_notes TEXT,
+      assigned_to INTEGER REFERENCES users(id),
+      appliance_id INTEGER,
+      last_completed TEXT,
+      next_due TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS completions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER NOT NULL REFERENCES tasks(id),
+      completed_at TEXT NOT NULL,
+      completed_by INTEGER REFERENCES users(id),
+      vendor_id INTEGER,
+      cost TEXT
+    );
+    CREATE TABLE IF NOT EXISTS vehicles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      make TEXT,
+      model TEXT,
+      year INTEGER,
+      colour TEXT,
+      rego_number TEXT,
+      rego_state TEXT,
+      vin TEXT,
+      purchase_date TEXT,
+      purchase_price REAL,
+      current_odometer INTEGER,
+      image_url TEXT,
+      rego_expiry TEXT,
+      insurance_provider TEXT,
+      insurance_expiry TEXT,
+      warranty_expiry_date TEXT,
+      warranty_expiry_km INTEGER,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS vehicle_services (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      vehicle_id INTEGER NOT NULL REFERENCES vehicles(id),
+      date TEXT NOT NULL,
+      odometer INTEGER,
+      vendor_id INTEGER,
+      cost REAL,
+      description TEXT NOT NULL,
+      service_type TEXT,
+      receipt_url TEXT,
+      is_diy INTEGER DEFAULT 0,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS fuel_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      vehicle_id INTEGER NOT NULL REFERENCES vehicles(id),
+      date TEXT NOT NULL,
+      odometer INTEGER NOT NULL,
+      litres REAL NOT NULL,
+      cost_total REAL NOT NULL,
+      cost_per_litre REAL,
+      station TEXT,
+      is_full_tank INTEGER DEFAULT 1,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS vendors (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      category TEXT,
+      phone TEXT,
+      email TEXT,
+      website TEXT,
+      notes TEXT,
+      rating INTEGER,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS quotes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      vendor_id INTEGER REFERENCES vendors(id),
+      description TEXT NOT NULL,
+      total REAL NOT NULL,
+      labor REAL,
+      materials REAL,
+      other REAL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      received_date TEXT,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS personal_access_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      scopes TEXT NOT NULL,
+      last_used_at TEXT,
+      expires_at TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string): Request {
+  return new Request(`http://localhost${url}`);
+}
+
+function insertTask(name: string, area = "Home"): number {
+  const result = sqlite
+    .prepare("INSERT INTO tasks (name, area, frequency) VALUES (?, ?, ?)")
+    .run(name, area, "weekly");
+  return Number(result.lastInsertRowid);
+}
+
+function insertCompletion(
+  taskId: number,
+  completedAt: string,
+  cost: string | null = null,
+  vendorId: number | null = null
+) {
+  sqlite
+    .prepare(
+      "INSERT INTO completions (task_id, completed_at, cost, vendor_id) VALUES (?, ?, ?, ?)"
+    )
+    .run(taskId, completedAt, cost, vendorId);
+}
+
+function insertVehicle(name: string): number {
+  const result = sqlite
+    .prepare("INSERT INTO vehicles (name) VALUES (?)")
+    .run(name);
+  return Number(result.lastInsertRowid);
+}
+
+function insertVehicleService(
+  vehicleId: number,
+  date: string,
+  cost: number,
+  description = "Service",
+  vendorId: number | null = null
+) {
+  sqlite
+    .prepare(
+      "INSERT INTO vehicle_services (vehicle_id, date, cost, description, vendor_id) VALUES (?, ?, ?, ?, ?)"
+    )
+    .run(vehicleId, date, cost, description, vendorId);
+}
+
+function insertFuelLog(
+  vehicleId: number,
+  date: string,
+  odometer: number,
+  litres: number,
+  costTotal: number
+) {
+  const costPerLitre = costTotal / litres;
+  sqlite
+    .prepare(
+      "INSERT INTO fuel_logs (vehicle_id, date, odometer, litres, cost_total, cost_per_litre) VALUES (?, ?, ?, ?, ?, ?)"
+    )
+    .run(vehicleId, date, odometer, litres, costTotal, costPerLitre);
+}
+
+function insertVendor(name: string): number {
+  const result = sqlite
+    .prepare("INSERT INTO vendors (name) VALUES (?)")
+    .run(name);
+  return Number(result.lastInsertRowid);
+}
+
+function insertQuote(
+  description: string,
+  total: number,
+  status: string,
+  receivedDate: string,
+  vendorId: number | null = null
+) {
+  sqlite
+    .prepare(
+      "INSERT INTO quotes (description, total, status, received_date, vendor_id) VALUES (?, ?, ?, ?, ?)"
+    )
+    .run(description, total, status, receivedDate, vendorId);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// EXPENSE STATS API
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Expense Stats API", () => {
+  let expenseRoute: typeof import("@/app/api/stats/expenses/route");
+
+  beforeEach(async () => {
+    expenseRoute = await import("@/app/api/stats/expenses/route");
+  });
+
+  function callGet(params = "") {
+    const req = makeRequest(`/api/stats/expenses${params ? `?${params}` : ""}`);
+    return expenseRoute.GET(req);
+  }
+
+  it("returns empty data when no expenses exist", async () => {
+    const res = await callGet("from=2026-01&to=2026-12");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBe(0);
+    expect(data.monthlyTotals).toEqual([]);
+    expect(data.categoryBreakdown).toEqual([]);
+    expect(data.topVendors).toEqual([]);
+    expect(data.vehicleSummaries).toEqual([]);
+  });
+
+  it("aggregates task completion costs", async () => {
+    const taskId = insertTask("Fix fence");
+    insertCompletion(taskId, "2026-03-15", "$150.00");
+    insertCompletion(taskId, "2026-03-20", "75");
+
+    const res = await callGet("from=2026-03&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBe(225);
+    expect(data.monthlyTotals).toHaveLength(1);
+    expect(data.monthlyTotals[0].month).toBe("2026-03");
+    expect(data.monthlyTotals[0].maintenance).toBe(225);
+    expect(data.monthlyTotals[0].total).toBe(225);
+  });
+
+  it("handles unparseable text cost fields gracefully", async () => {
+    const taskId = insertTask("Test task");
+    insertCompletion(taskId, "2026-03-10", "$50");
+    insertCompletion(taskId, "2026-03-11", "N/A");
+    insertCompletion(taskId, "2026-03-12", "free");
+    insertCompletion(taskId, "2026-03-13", "");
+
+    const res = await callGet("from=2026-03&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    // Only the $50 should be counted
+    expect(data.grandTotal).toBe(50);
+  });
+
+  it("aggregates vehicle service costs", async () => {
+    const vehicleId = insertVehicle("My Car");
+    insertVehicleService(vehicleId, "2026-04-01", 350, "Oil change");
+    insertVehicleService(vehicleId, "2026-04-15", 1200, "Brakes");
+
+    const res = await callGet("from=2026-04&to=2026-04");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBe(1550);
+    expect(data.monthlyTotals[0].maintenance).toBe(1550);
+  });
+
+  it("aggregates fuel costs", async () => {
+    const vehicleId = insertVehicle("Family Car");
+    insertFuelLog(vehicleId, "2026-05-01", 50000, 40, 80);
+    insertFuelLog(vehicleId, "2026-05-15", 50500, 42, 88.2);
+
+    const res = await callGet("from=2026-05&to=2026-05");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBeCloseTo(168.2);
+    expect(data.monthlyTotals[0].fuel).toBeCloseTo(168.2);
+  });
+
+  it("only counts accepted quotes", async () => {
+    insertQuote("Roof repair", 5000, "accepted", "2026-06-01");
+    insertQuote("Fence quote", 2000, "pending", "2026-06-15");
+    insertQuote("Rejected job", 3000, "rejected", "2026-06-20");
+
+    const res = await callGet("from=2026-06&to=2026-06");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBe(5000);
+    expect(data.monthlyTotals[0].quotes).toBe(5000);
+  });
+
+  it("groups expenses by month", async () => {
+    const vehicleId = insertVehicle("Car");
+    insertFuelLog(vehicleId, "2026-01-15", 10000, 40, 80);
+    insertFuelLog(vehicleId, "2026-02-15", 10500, 42, 88);
+    insertFuelLog(vehicleId, "2026-03-15", 11000, 38, 76);
+
+    const res = await callGet("from=2026-01&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.monthlyTotals).toHaveLength(3);
+    expect(data.monthlyTotals[0].month).toBe("2026-01");
+    expect(data.monthlyTotals[1].month).toBe("2026-02");
+    expect(data.monthlyTotals[2].month).toBe("2026-03");
+  });
+
+  it("groups expenses by year when period=year", async () => {
+    const vehicleId = insertVehicle("Car");
+    insertFuelLog(vehicleId, "2025-06-15", 10000, 40, 80);
+    insertFuelLog(vehicleId, "2026-06-15", 11000, 42, 88);
+
+    const res = await callGet("period=year&from=2025-01&to=2026-12");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.monthlyTotals).toHaveLength(2);
+    expect(data.monthlyTotals[0].month).toBe("2025");
+    expect(data.monthlyTotals[1].month).toBe("2026");
+  });
+
+  it("provides category breakdown", async () => {
+    const vehicleId = insertVehicle("Car");
+    const taskId = insertTask("Paint");
+
+    insertFuelLog(vehicleId, "2026-03-10", 10000, 40, 80);
+    insertVehicleService(vehicleId, "2026-03-15", 200, "Service");
+    insertCompletion(taskId, "2026-03-20", "100");
+    insertQuote("Work", 500, "accepted", "2026-03-25");
+
+    const res = await callGet("from=2026-03&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    const categories = data.categoryBreakdown as { category: string; total: number }[];
+    const fuel = categories.find((c: { category: string }) => c.category === "Fuel");
+    const maintenance = categories.find((c: { category: string }) => c.category === "Maintenance");
+    const quotesCategory = categories.find((c: { category: string }) => c.category === "Quotes");
+
+    expect(fuel?.total).toBe(80);
+    expect(maintenance?.total).toBe(300); // 200 service + 100 completion
+    expect(quotesCategory?.total).toBe(500);
+  });
+
+  it("provides top vendors by spend", async () => {
+    const vendor1 = insertVendor("Mechanic Pro");
+    const vendor2 = insertVendor("Budget Fix");
+    const vehicleId = insertVehicle("Car");
+
+    insertVehicleService(vehicleId, "2026-03-01", 500, "Major service", vendor1);
+    insertVehicleService(vehicleId, "2026-03-15", 200, "Minor fix", vendor2);
+    insertVehicleService(vehicleId, "2026-03-20", 300, "Another service", vendor1);
+
+    const res = await callGet("from=2026-03&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.topVendors).toHaveLength(2);
+    expect(data.topVendors[0].vendorName).toBe("Mechanic Pro");
+    expect(data.topVendors[0].total).toBe(800);
+    expect(data.topVendors[1].vendorName).toBe("Budget Fix");
+    expect(data.topVendors[1].total).toBe(200);
+  });
+
+  it("provides per-vehicle cost summaries", async () => {
+    const car1 = insertVehicle("Sedan");
+    const car2 = insertVehicle("SUV");
+
+    insertFuelLog(car1, "2026-03-10", 10000, 40, 80);
+    insertFuelLog(car2, "2026-03-10", 20000, 50, 100);
+    insertVehicleService(car1, "2026-03-15", 300, "Oil change");
+
+    const res = await callGet("from=2026-03&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.vehicleSummaries).toHaveLength(2);
+
+    const sedan = data.vehicleSummaries.find(
+      (v: { vehicleName: string }) => v.vehicleName === "Sedan"
+    );
+    const suv = data.vehicleSummaries.find(
+      (v: { vehicleName: string }) => v.vehicleName === "SUV"
+    );
+
+    expect(sedan.fuel).toBe(80);
+    expect(sedan.services).toBe(300);
+    expect(sedan.total).toBe(380);
+    expect(suv.fuel).toBe(100);
+    expect(suv.services).toBe(0);
+    expect(suv.total).toBe(100);
+  });
+
+  it("filters by date range", async () => {
+    const vehicleId = insertVehicle("Car");
+    insertFuelLog(vehicleId, "2026-01-15", 10000, 40, 80);
+    insertFuelLog(vehicleId, "2026-06-15", 15000, 42, 88);
+
+    // Only query January
+    const res = await callGet("from=2026-01&to=2026-01");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBe(80);
+    expect(data.monthlyTotals).toHaveLength(1);
+  });
+
+  it("handles cost text with currency symbols and commas", async () => {
+    const taskId = insertTask("Expensive repair");
+    insertCompletion(taskId, "2026-03-10", "$1,234.56");
+
+    const res = await callGet("from=2026-03&to=2026-03");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.grandTotal).toBeCloseTo(1234.56);
+  });
+});

--- a/src/app/api/stats/expenses/route.ts
+++ b/src/app/api/stats/expenses/route.ts
@@ -1,0 +1,348 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import {
+  completions,
+  vehicleServices,
+  fuelLogs,
+  quotes,
+  vehicles,
+  vendors,
+} from "@/lib/db/schema";
+import { sql, eq, gte, lte, and } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Parse a text cost value like "$50", "50.00", "$1,234.56" into a number.
+ * Returns null if unparseable.
+ */
+function parseCostText(value: string | null): number | null {
+  if (!value) return null;
+  // Strip currency symbols, commas, whitespace
+  const cleaned = value.replace(/[$,\s]/g, "");
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? null : num;
+}
+
+interface MonthlyExpense {
+  month: string;
+  maintenance: number;
+  fuel: number;
+  quotes: number;
+  total: number;
+}
+
+interface CategoryBreakdown {
+  category: string;
+  total: number;
+}
+
+interface VendorSpend {
+  vendorId: number;
+  vendorName: string;
+  total: number;
+}
+
+interface VehicleCostSummary {
+  vehicleId: number;
+  vehicleName: string;
+  fuel: number;
+  services: number;
+  total: number;
+}
+
+export async function GET(request: Request) {
+  try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
+    const url = new URL(request.url);
+    const period = url.searchParams.get("period") || "month";
+    const from = url.searchParams.get("from");
+    const to = url.searchParams.get("to");
+
+    // Default ranges: last 12 months for month view, last 5 years for year view
+    const now = new Date();
+    let fromDate: string;
+    let toDate: string;
+
+    if (from) {
+      fromDate = `${from}-01`;
+    } else if (period === "year") {
+      fromDate = `${now.getFullYear() - 4}-01-01`;
+    } else {
+      const d = new Date(now.getFullYear(), now.getMonth() - 11, 1);
+      fromDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-01`;
+    }
+
+    if (to) {
+      // End of the given month
+      const [y, m] = to.split("-").map(Number);
+      const lastDay = new Date(y, m, 0).getDate();
+      toDate = `${to}-${String(lastDay).padStart(2, "0")}`;
+    } else {
+      toDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    }
+
+    // ── Fetch raw data ──────────────────────────────────────────────────
+
+    // 1. Task completions with cost (text field, needs parsing)
+    const rawCompletions = await db
+      .select({
+        completedAt: completions.completedAt,
+        cost: completions.cost,
+        vendorId: completions.vendorId,
+      })
+      .from(completions)
+      .where(
+        and(
+          sql`${completions.cost} IS NOT NULL`,
+          gte(completions.completedAt, fromDate),
+          lte(completions.completedAt, toDate)
+        )
+      );
+
+    // 2. Vehicle services
+    const rawServices = await db
+      .select({
+        date: vehicleServices.date,
+        cost: vehicleServices.cost,
+        vehicleId: vehicleServices.vehicleId,
+        vendorId: vehicleServices.vendorId,
+      })
+      .from(vehicleServices)
+      .where(
+        and(
+          sql`${vehicleServices.cost} IS NOT NULL`,
+          gte(vehicleServices.date, fromDate),
+          lte(vehicleServices.date, toDate)
+        )
+      );
+
+    // 3. Fuel logs
+    const rawFuel = await db
+      .select({
+        date: fuelLogs.date,
+        costTotal: fuelLogs.costTotal,
+        vehicleId: fuelLogs.vehicleId,
+      })
+      .from(fuelLogs)
+      .where(
+        and(
+          gte(fuelLogs.date, fromDate),
+          lte(fuelLogs.date, toDate)
+        )
+      );
+
+    // 4. Accepted quotes
+    const rawQuotes = await db
+      .select({
+        receivedDate: quotes.receivedDate,
+        createdAt: quotes.createdAt,
+        total: quotes.total,
+        vendorId: quotes.vendorId,
+      })
+      .from(quotes)
+      .where(
+        and(
+          eq(quotes.status, "accepted"),
+          sql`COALESCE(${quotes.receivedDate}, ${quotes.createdAt}) >= ${fromDate}`,
+          sql`COALESCE(${quotes.receivedDate}, ${quotes.createdAt}) <= ${toDate}`
+        )
+      );
+
+    // 5. All vehicles for names
+    const allVehicles = await db
+      .select({ id: vehicles.id, name: vehicles.name })
+      .from(vehicles);
+    const vehicleMap = new Map(allVehicles.map((v) => [v.id, v.name]));
+
+    // 6. All vendors for names
+    const allVendors = await db
+      .select({ id: vendors.id, name: vendors.name })
+      .from(vendors);
+    const vendorMap = new Map(allVendors.map((v) => [v.id, v.name]));
+
+    // ── Aggregate monthly data ──────────────────────────────────────────
+
+    function periodKey(dateStr: string): string {
+      if (period === "year") return dateStr.substring(0, 4);
+      return dateStr.substring(0, 7);
+    }
+
+    const monthlyMap = new Map<string, MonthlyExpense>();
+
+    function getMonth(key: string): MonthlyExpense {
+      if (!monthlyMap.has(key)) {
+        monthlyMap.set(key, {
+          month: key,
+          maintenance: 0,
+          fuel: 0,
+          quotes: 0,
+          total: 0,
+        });
+      }
+      return monthlyMap.get(key)!;
+    }
+
+    // Task completions → maintenance category
+    for (const row of rawCompletions) {
+      const cost = parseCostText(row.cost);
+      if (cost === null || cost <= 0) continue;
+      const key = periodKey(row.completedAt);
+      const m = getMonth(key);
+      m.maintenance += cost;
+      m.total += cost;
+    }
+
+    // Vehicle services → maintenance category
+    for (const row of rawServices) {
+      if (!row.cost || row.cost <= 0) continue;
+      const key = periodKey(row.date);
+      const m = getMonth(key);
+      m.maintenance += row.cost;
+      m.total += row.cost;
+    }
+
+    // Fuel logs → fuel category
+    for (const row of rawFuel) {
+      if (!row.costTotal || row.costTotal <= 0) continue;
+      const key = periodKey(row.date);
+      const m = getMonth(key);
+      m.fuel += row.costTotal;
+      m.total += row.costTotal;
+    }
+
+    // Accepted quotes → quotes category
+    for (const row of rawQuotes) {
+      if (!row.total || row.total <= 0) continue;
+      const dateStr = row.receivedDate || row.createdAt || "";
+      if (!dateStr) continue;
+      const key = periodKey(dateStr);
+      const m = getMonth(key);
+      m.quotes += row.total;
+      m.total += row.total;
+    }
+
+    const monthlyTotals = Array.from(monthlyMap.values()).sort((a, b) =>
+      a.month.localeCompare(b.month)
+    );
+
+    // ── Category breakdown ──────────────────────────────────────────────
+
+    let totalMaintenance = 0;
+    let totalFuel = 0;
+    let totalQuotes = 0;
+
+    for (const m of monthlyTotals) {
+      totalMaintenance += m.maintenance;
+      totalFuel += m.fuel;
+      totalQuotes += m.quotes;
+    }
+
+    const categoryBreakdown: CategoryBreakdown[] = [
+      { category: "Maintenance", total: Math.round(totalMaintenance * 100) / 100 },
+      { category: "Fuel", total: Math.round(totalFuel * 100) / 100 },
+      { category: "Quotes", total: Math.round(totalQuotes * 100) / 100 },
+    ].filter((c) => c.total > 0);
+
+    // ── Top vendors ─────────────────────────────────────────────────────
+
+    const vendorTotals = new Map<number, number>();
+
+    for (const row of rawCompletions) {
+      if (!row.vendorId) continue;
+      const cost = parseCostText(row.cost);
+      if (cost === null || cost <= 0) continue;
+      vendorTotals.set(row.vendorId, (vendorTotals.get(row.vendorId) || 0) + cost);
+    }
+
+    for (const row of rawServices) {
+      if (!row.vendorId || !row.cost || row.cost <= 0) continue;
+      vendorTotals.set(
+        row.vendorId,
+        (vendorTotals.get(row.vendorId) || 0) + row.cost
+      );
+    }
+
+    for (const row of rawQuotes) {
+      if (!row.vendorId || !row.total || row.total <= 0) continue;
+      vendorTotals.set(
+        row.vendorId,
+        (vendorTotals.get(row.vendorId) || 0) + row.total
+      );
+    }
+
+    const topVendors: VendorSpend[] = Array.from(vendorTotals.entries())
+      .map(([vendorId, total]) => ({
+        vendorId,
+        vendorName: vendorMap.get(vendorId) || "Unknown",
+        total: Math.round(total * 100) / 100,
+      }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 10);
+
+    // ── Per-vehicle cost summary ────────────────────────────────────────
+
+    const vehicleFuel = new Map<number, number>();
+    const vehicleServiceCost = new Map<number, number>();
+
+    for (const row of rawFuel) {
+      if (!row.costTotal || row.costTotal <= 0) continue;
+      vehicleFuel.set(
+        row.vehicleId,
+        (vehicleFuel.get(row.vehicleId) || 0) + row.costTotal
+      );
+    }
+
+    for (const row of rawServices) {
+      if (!row.cost || row.cost <= 0) continue;
+      vehicleServiceCost.set(
+        row.vehicleId,
+        (vehicleServiceCost.get(row.vehicleId) || 0) + row.cost
+      );
+    }
+
+    const vehicleIds = new Set([
+      ...vehicleFuel.keys(),
+      ...vehicleServiceCost.keys(),
+    ]);
+
+    const vehicleSummaries: VehicleCostSummary[] = Array.from(vehicleIds)
+      .map((vehicleId) => {
+        const fuel = vehicleFuel.get(vehicleId) || 0;
+        const services = vehicleServiceCost.get(vehicleId) || 0;
+        return {
+          vehicleId,
+          vehicleName: vehicleMap.get(vehicleId) || "Unknown",
+          fuel: Math.round(fuel * 100) / 100,
+          services: Math.round(services * 100) / 100,
+          total: Math.round((fuel + services) * 100) / 100,
+        };
+      })
+      .sort((a, b) => b.total - a.total);
+
+    // ── Grand total ─────────────────────────────────────────────────────
+
+    const grandTotal =
+      Math.round((totalMaintenance + totalFuel + totalQuotes) * 100) / 100;
+
+    return NextResponse.json({
+      period,
+      from: fromDate,
+      to: toDate,
+      grandTotal,
+      monthlyTotals,
+      categoryBreakdown,
+      topVendors,
+      vehicleSummaries,
+    });
+  } catch (error) {
+    console.error("Error fetching expense stats:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch expense stats" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/stats/expenses/page.tsx
+++ b/src/app/stats/expenses/page.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DollarSign,
+  Fuel,
+  Wrench,
+  FileText,
+  TrendingUp,
+  Car,
+  Store,
+} from "lucide-react";
+import { AppLayout } from "@/components/layout/AppLayout";
+import Link from "next/link";
+
+interface MonthlyExpense {
+  month: string;
+  maintenance: number;
+  fuel: number;
+  quotes: number;
+  total: number;
+}
+
+interface CategoryBreakdown {
+  category: string;
+  total: number;
+}
+
+interface VendorSpend {
+  vendorId: number;
+  vendorName: string;
+  total: number;
+}
+
+interface VehicleCostSummary {
+  vehicleId: number;
+  vehicleName: string;
+  fuel: number;
+  services: number;
+  total: number;
+}
+
+interface ExpenseData {
+  period: string;
+  from: string;
+  to: string;
+  grandTotal: number;
+  monthlyTotals: MonthlyExpense[];
+  categoryBreakdown: CategoryBreakdown[];
+  topVendors: VendorSpend[];
+  vehicleSummaries: VehicleCostSummary[];
+}
+
+const CATEGORY_COLORS: Record<string, { bar: string; text: string; bg: string }> = {
+  Maintenance: {
+    bar: "bg-amber-500",
+    text: "text-amber-700 dark:text-amber-400",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+  },
+  Fuel: {
+    bar: "bg-green-500",
+    text: "text-green-700 dark:text-green-400",
+    bg: "bg-green-50 dark:bg-green-950/30",
+  },
+  Quotes: {
+    bar: "bg-blue-500",
+    text: "text-blue-700 dark:text-blue-400",
+    bg: "bg-blue-50 dark:bg-blue-950/30",
+  },
+};
+
+const CATEGORY_ICONS: Record<string, typeof DollarSign> = {
+  Maintenance: Wrench,
+  Fuel: Fuel,
+  Quotes: FileText,
+};
+
+function formatCurrency(value: number): string {
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+function formatMonth(key: string): string {
+  if (key.length === 4) return key; // Year
+  const [y, m] = key.split("-");
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[parseInt(m, 10) - 1]} ${y.slice(2)}`;
+}
+
+function SpendBarChart({
+  data,
+  label,
+}: {
+  data: MonthlyExpense[];
+  label: string;
+}) {
+  if (data.length === 0) return null;
+
+  const maxVal = Math.max(...data.map((d) => d.total), 0.01);
+
+  return (
+    <div>
+      <p className="text-sm font-medium mb-2">{label}</p>
+      <div className="flex items-end gap-1 h-32">
+        {data.map((d) => {
+          const height = d.total > 0 ? (d.total / maxVal) * 100 : 0;
+          // Stack: fuel (bottom), maintenance (middle), quotes (top)
+          const fuelPct = d.total > 0 ? (d.fuel / d.total) * height : 0;
+          const maintPct = d.total > 0 ? (d.maintenance / d.total) * height : 0;
+          const quotePct = d.total > 0 ? (d.quotes / d.total) * height : 0;
+
+          return (
+            <div
+              key={d.month}
+              className="flex-1 flex flex-col items-center gap-1 min-w-0"
+            >
+              <div className="w-full flex flex-col items-center justify-end h-24">
+                {d.total > 0 ? (
+                  <div
+                    className="w-full flex flex-col-reverse rounded-t overflow-hidden min-h-[4px]"
+                    style={{ height: `${Math.max(height, 4)}%` }}
+                    title={`${formatMonth(d.month)}: ${formatCurrency(d.total)}`}
+                  >
+                    {fuelPct > 0 && (
+                      <div
+                        className="w-full bg-green-500"
+                        style={{ height: `${(fuelPct / height) * 100}%` }}
+                      />
+                    )}
+                    {maintPct > 0 && (
+                      <div
+                        className="w-full bg-amber-500"
+                        style={{ height: `${(maintPct / height) * 100}%` }}
+                      />
+                    )}
+                    {quotePct > 0 && (
+                      <div
+                        className="w-full bg-blue-500"
+                        style={{ height: `${(quotePct / height) * 100}%` }}
+                      />
+                    )}
+                  </div>
+                ) : (
+                  <div className="w-full bg-gray-200 dark:bg-zinc-700 rounded-t h-[4px]" />
+                )}
+              </div>
+              <span className="text-[10px] text-muted-foreground truncate w-full text-center">
+                {formatMonth(d.month)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {/* Legend */}
+      <div className="flex gap-4 mt-2 justify-center">
+        <div className="flex items-center gap-1">
+          <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
+          <span className="text-[11px] text-muted-foreground">Fuel</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2.5 h-2.5 rounded-full bg-amber-500" />
+          <span className="text-[11px] text-muted-foreground">Maintenance</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2.5 h-2.5 rounded-full bg-blue-500" />
+          <span className="text-[11px] text-muted-foreground">Quotes</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ExpensesPage() {
+  const [data, setData] = useState<ExpenseData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [period, setPeriod] = useState<"month" | "year">("month");
+
+  const fetchExpenses = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/stats/expenses?period=${period}`);
+      if (res.ok) {
+        const json = await res.json();
+        setData(json);
+      }
+    } catch (error) {
+      console.error("Error fetching expenses:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [period]);
+
+  useEffect(() => {
+    fetchExpenses();
+  }, [fetchExpenses]);
+
+  if (isLoading) {
+    return (
+      <AppLayout title="Expenses">
+        <div className="flex items-center justify-center h-64">
+          <div className="text-muted-foreground">Loading expenses...</div>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  if (!data) {
+    return (
+      <AppLayout title="Expenses">
+        <div className="text-center text-muted-foreground">
+          Failed to load expense data
+        </div>
+      </AppLayout>
+    );
+  }
+
+  const chartData = data.monthlyTotals.slice(-12);
+
+  return (
+    <AppLayout title="Expenses">
+      <div className="space-y-6">
+        {/* Period selector + grand total */}
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-muted-foreground">
+              Total spending ({period === "year" ? "yearly" : "monthly"} view)
+            </p>
+            <p className="text-3xl font-bold">{formatCurrency(data.grandTotal)}</p>
+          </div>
+          <div className="flex rounded-lg border border-border overflow-hidden">
+            <button
+              onClick={() => setPeriod("month")}
+              className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+                period === "month"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-card text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              Monthly
+            </button>
+            <button
+              onClick={() => setPeriod("year")}
+              className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+                period === "year"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-card text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              Yearly
+            </button>
+          </div>
+        </div>
+
+        {/* Category breakdown cards */}
+        {data.categoryBreakdown.length > 0 && (
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {data.categoryBreakdown.map((cat) => {
+              const colors = CATEGORY_COLORS[cat.category] || {
+                bar: "bg-gray-500",
+                text: "text-gray-700 dark:text-gray-400",
+                bg: "bg-gray-50 dark:bg-gray-950/30",
+              };
+              const Icon = CATEGORY_ICONS[cat.category] || DollarSign;
+              const pct =
+                data.grandTotal > 0
+                  ? Math.round((cat.total / data.grandTotal) * 100)
+                  : 0;
+
+              return (
+                <div key={cat.category} className={`p-3 ${colors.bg} rounded-lg`}>
+                  <div className="flex items-center gap-2 mb-1">
+                    <Icon className={`h-4 w-4 ${colors.text}`} />
+                    <span className="text-xs text-muted-foreground">
+                      {cat.category}
+                    </span>
+                  </div>
+                  <p className={`text-lg font-semibold ${colors.text}`}>
+                    {formatCurrency(cat.total)}
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {pct}% of total
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Spending trend chart */}
+        {chartData.length > 0 ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <TrendingUp className="h-4 w-4" />
+                Spending Over Time
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SpendBarChart
+                data={chartData}
+                label={period === "year" ? "Yearly Totals" : "Monthly Totals"}
+              />
+            </CardContent>
+          </Card>
+        ) : (
+          <Card>
+            <CardContent className="py-8">
+              <p className="text-sm text-muted-foreground text-center">
+                No expense data recorded yet. Costs from task completions, vehicle
+                services, fuel logs, and accepted quotes will appear here.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+
+        <div className="grid md:grid-cols-2 gap-6">
+          {/* Top vendors */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Store className="h-4 w-4" />
+                Top Vendors
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {data.topVendors.length > 0 ? (
+                <div className="space-y-3">
+                  {data.topVendors.map((vendor) => {
+                    const maxVendor = data.topVendors[0]?.total || 1;
+                    const pct = (vendor.total / maxVendor) * 100;
+                    return (
+                      <div key={vendor.vendorId} className="space-y-1">
+                        <div className="flex justify-between text-sm">
+                          <span className="font-medium truncate">
+                            {vendor.vendorName}
+                          </span>
+                          <span className="text-muted-foreground shrink-0 ml-2">
+                            {formatCurrency(vendor.total)}
+                          </span>
+                        </div>
+                        <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-purple-500 rounded-full"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  No vendor expenses recorded
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Per-vehicle costs */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Car className="h-4 w-4" />
+                Vehicle Costs
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {data.vehicleSummaries.length > 0 ? (
+                <div className="space-y-4">
+                  {data.vehicleSummaries.map((v) => (
+                    <div key={v.vehicleId} className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-sm">
+                          {v.vehicleName}
+                        </span>
+                        <span className="text-sm font-semibold">
+                          {formatCurrency(v.total)}
+                        </span>
+                      </div>
+                      <div className="flex gap-3 text-xs text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <div className="w-2 h-2 rounded-full bg-green-500" />
+                          Fuel: {formatCurrency(v.fuel)}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <div className="w-2 h-2 rounded-full bg-amber-500" />
+                          Services: {formatCurrency(v.services)}
+                        </span>
+                      </div>
+                      {v.total > 0 && (
+                        <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden flex">
+                          <div
+                            className="h-full bg-green-500"
+                            style={{
+                              width: `${(v.fuel / v.total) * 100}%`,
+                            }}
+                          />
+                          <div
+                            className="h-full bg-amber-500"
+                            style={{
+                              width: `${(v.services / v.total) * 100}%`,
+                            }}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground text-center py-4">
+                  No vehicle expenses recorded
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Back to stats link */}
+        <div className="text-center">
+          <Link
+            href="/stats"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Back to Statistics
+          </Link>
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -10,7 +10,9 @@ import {
   TrendingUp,
   Calendar,
   ListTodo,
+  DollarSign,
 } from "lucide-react";
+import Link from "next/link";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { areaBarColors } from "@/lib/area-colors";
 
@@ -219,6 +221,28 @@ export default function StatsPage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Expense Summary Link */}
+        <Link href="/stats/expenses" className="block group">
+          <Card className="transition-colors group-hover:border-emerald-200 dark:group-hover:border-emerald-800">
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 bg-emerald-100 dark:bg-emerald-950 rounded-lg">
+                    <DollarSign className="h-5 w-5 text-emerald-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">Expense Summary</p>
+                    <p className="text-sm text-muted-foreground">
+                      View spending by category, vendor, and vehicle
+                    </p>
+                  </div>
+                </div>
+                <span className="text-muted-foreground">&rarr;</span>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
 
         {/* Most Completed Tasks */}
         <Card>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { DailyTasksList } from "./DailyTasksList";
 import { StatsRow } from "./StatsRow";
 import { TodaysMealCard } from "./TodaysMealCard";
 import { ShoppingOverview } from "./ShoppingOverview";
+import { ExpenseWidget } from "./ExpenseWidget";
 import { RecentCompletions } from "./RecentCompletions";
 import { parseISO, isToday, isBefore, addDays, startOfDay } from "date-fns";
 
@@ -107,10 +108,11 @@ export function Dashboard() {
       {/* Stats overview */}
       <StatsRow />
 
-      {/* Quick glance row: meal + shopping */}
-      <div className="grid gap-4 md:grid-cols-2">
+      {/* Quick glance row: meal + shopping + spending */}
+      <div className="grid gap-4 md:grid-cols-3">
         <TodaysMealCard />
         <ShoppingOverview />
+        <ExpenseWidget />
       </div>
 
       {/* Recent completions */}

--- a/src/components/dashboard/ExpenseWidget.tsx
+++ b/src/components/dashboard/ExpenseWidget.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DollarSign } from "lucide-react";
+import Link from "next/link";
+
+interface CategoryBreakdown {
+  category: string;
+  total: number;
+}
+
+interface ExpenseWidgetData {
+  grandTotal: number;
+  categoryBreakdown: CategoryBreakdown[];
+}
+
+const CATEGORY_DOT_COLORS: Record<string, string> = {
+  Maintenance: "bg-amber-500",
+  Fuel: "bg-green-500",
+  Quotes: "bg-blue-500",
+};
+
+function formatCurrency(value: number): string {
+  return `$${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}
+
+export function ExpenseWidget() {
+  const [data, setData] = useState<ExpenseWidgetData | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    // Fetch current month expenses
+    const now = new Date();
+    const monthStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+    fetch(`/api/stats/expenses?period=month&from=${monthStr}&to=${monthStr}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (json) {
+          setData({
+            grandTotal: json.grandTotal,
+            categoryBreakdown: json.categoryBreakdown,
+          });
+        }
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  if (!loaded) return null;
+
+  return (
+    <Link href="/stats/expenses" className="block group">
+      <Card className="h-full transition-colors group-hover:border-emerald-200 dark:group-hover:border-emerald-800">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+            <DollarSign className="h-4 w-4" />
+            Spending This Month
+            {data && data.grandTotal > 0 && (
+              <span className="ml-auto text-xs bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300 rounded-full px-2 py-0.5 font-medium">
+                {formatCurrency(data.grandTotal)}
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {data && data.categoryBreakdown.length > 0 ? (
+            <div className="space-y-2">
+              {data.categoryBreakdown.map((cat) => {
+                const pct =
+                  data.grandTotal > 0
+                    ? Math.round((cat.total / data.grandTotal) * 100)
+                    : 0;
+                return (
+                  <div key={cat.category} className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+                          CATEGORY_DOT_COLORS[cat.category] || "bg-gray-500"
+                        }`}
+                      />
+                      <span className="font-medium">{cat.category}</span>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {formatCurrency(cat.total)} ({pct}%)
+                    </span>
+                  </div>
+                );
+              })}
+              {/* Stacked progress bar */}
+              {data.grandTotal > 0 && (
+                <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden flex mt-1">
+                  {data.categoryBreakdown.map((cat) => {
+                    const pct = (cat.total / data.grandTotal) * 100;
+                    const colorClass =
+                      CATEGORY_DOT_COLORS[cat.category] || "bg-gray-500";
+                    return (
+                      <div
+                        key={cat.category}
+                        className={`h-full ${colorClass}`}
+                        style={{ width: `${pct}%` }}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground italic">
+              No expenses this month
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -8,3 +8,4 @@ export { StatsRow } from "./StatsRow";
 export { TodaysMealCard } from "./TodaysMealCard";
 export { ShoppingOverview } from "./ShoppingOverview";
 export { RecentCompletions } from "./RecentCompletions";
+export { ExpenseWidget } from "./ExpenseWidget";


### PR DESCRIPTION
## Summary

- Adds `GET /api/stats/expenses` endpoint that aggregates costs from task completions, vehicle services, fuel logs, and accepted quotes with `?period=month|year&from=YYYY-MM&to=YYYY-MM` filtering
- Adds `/stats/expenses` page with stacked bar chart of spending over time, category breakdown cards (Maintenance/Fuel/Quotes), top vendors by spend, and per-vehicle cost summaries with fuel/service split
- Adds `ExpenseWidget` to the main dashboard showing current month spending with category breakdown and stacked progress bar
- Links expenses page from the existing `/stats` page
- Handles `completions.cost` TEXT field parsing (strips `$`, commas, whitespace; skips unparseable values)

Closes #43

## Test plan

- [x] 13 unit tests covering: empty data, text cost parsing, currency symbols/commas, unparseable values, all entity types, period grouping (month/year), category breakdown, top vendors, per-vehicle summaries, date filtering
- [x] E2E tests covering: page navigation, period selector toggle, empty state rendering, vendor/vehicle sections, back-to-stats link, stats page link, dashboard widget visibility and navigation
- [x] `npm test` passes (72/72)
- [x] `npm run lint` passes (0 errors, no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
