### PR TITLE
Add shopping list aisle/category sorting

### DIFF
--- a/e2e/shopping-categories.spec.ts
+++ b/e2e/shopping-categories.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect, Page } from "@playwright/test";
+import { cleanupTestData } from "./cleanup";
+
+const TEST_LIST_NAME = `E2E Categories ${Date.now()}`;
+
+async function dismissUserPickerIfVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  const dialog = page.getByRole("dialog");
+  const isVisible = await dialog.isVisible().catch(() => false);
+  if (isVisible) {
+    const heading = dialog.getByRole("heading");
+    const text = await heading.textContent().catch(() => "");
+    if (text === "Who are you?" || text === "Switch User") {
+      const userButton = dialog.locator("button").first();
+      if (await userButton.isVisible().catch(() => false)) {
+        await userButton.click();
+        await expect(dialog).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+  }
+}
+
+test.afterAll(async ({ request }) => {
+  await cleanupTestData(request, "shopping", "E2E Categories%");
+});
+
+test.describe.serial("Shopping List Category Grouping", () => {
+  test("should create a list and add items that get auto-categorized", async ({
+    page,
+  }) => {
+    await page.goto("/shopping");
+    await dismissUserPickerIfVisible(page);
+    await page.waitForLoadState("networkidle");
+
+    // Create a new list
+    const createListBtn = page.getByRole("button", { name: "Create List" });
+    const plusBtn = page
+      .locator("button")
+      .filter({ has: page.locator("svg.lucide-plus") })
+      .first();
+
+    if (await createListBtn.isVisible().catch(() => false)) {
+      await createListBtn.click();
+    } else {
+      await plusBtn.click();
+    }
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel("Name").fill(TEST_LIST_NAME);
+
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/shopping/lists") &&
+        resp.request().method() === "POST"
+    );
+    await dialog.getByRole("button", { name: "Create" }).click();
+    await responsePromise;
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    await page.waitForLoadState("networkidle");
+
+    // Select our list
+    const selectTrigger = page.locator("button[role='combobox']").first();
+    if (await selectTrigger.isVisible().catch(() => false)) {
+      await selectTrigger.click();
+      const listOption = page.getByRole("option", {
+        name: new RegExp(TEST_LIST_NAME),
+      });
+      if (await listOption.isVisible().catch(() => false)) {
+        await listOption.click();
+      }
+    }
+    await page.waitForLoadState("networkidle");
+
+    // Add items from different categories
+    const addInput = page.getByPlaceholder("Add item...");
+
+    // Add a dairy item
+    await addInput.fill("Milk");
+    await addInput.press("Enter");
+    await page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/shopping/items") &&
+        resp.request().method() === "POST"
+    );
+
+    // Add a bakery item
+    await addInput.fill("Bread");
+    await addInput.press("Enter");
+    await page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/shopping/items") &&
+        resp.request().method() === "POST"
+    );
+
+    // Add a meat item
+    await addInput.fill("Chicken");
+    await addInput.press("Enter");
+    await page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/shopping/items") &&
+        resp.request().method() === "POST"
+    );
+
+    // Wait for items to render
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(500);
+
+    // Verify category section headers appear
+    await expect(page.getByText("Dairy").first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Bakery").first()).toBeVisible();
+    await expect(page.getByText("Meat & Seafood").first()).toBeVisible();
+
+    // Verify items are visible
+    await expect(page.getByText("Milk")).toBeVisible();
+    await expect(page.getByText("Bread")).toBeVisible();
+    await expect(page.getByText("Chicken")).toBeVisible();
+  });
+
+  test("should allow manual category change via dropdown", async ({
+    page,
+  }) => {
+    await page.goto("/shopping");
+    await dismissUserPickerIfVisible(page);
+    await page.waitForLoadState("networkidle");
+
+    // Select our test list
+    const selectTrigger = page.locator("button[role='combobox']").first();
+    if (await selectTrigger.isVisible().catch(() => false)) {
+      await selectTrigger.click();
+      const listOption = page.getByRole("option", {
+        name: new RegExp(TEST_LIST_NAME),
+      });
+      if (await listOption.isVisible().catch(() => false)) {
+        await listOption.click();
+        await page.waitForLoadState("networkidle");
+      }
+    }
+
+    // Find the Milk item row and hover to reveal the category dropdown
+    const milkRow = page
+      .locator("div.flex.items-center", { hasText: "Milk" })
+      .first();
+    await milkRow.hover();
+
+    // Click the category select within the milk row
+    const categoryTrigger = milkRow.locator("button[role='combobox']");
+    if (await categoryTrigger.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await categoryTrigger.click();
+
+      // Select "Frozen" category
+      const frozenOption = page.getByRole("option", { name: "Frozen" });
+      if (await frozenOption.isVisible().catch(() => false)) {
+        const updatePromise = page.waitForResponse(
+          (resp) =>
+            resp.url().includes("/api/shopping/items/") &&
+            resp.request().method() === "PUT"
+        );
+        await frozenOption.click();
+        await updatePromise;
+
+        // Wait for re-render
+        await page.waitForTimeout(500);
+
+        // Verify "Frozen" section header now appears
+        await expect(page.getByText("Frozen").first()).toBeVisible({
+          timeout: 5000,
+        });
+      }
+    }
+  });
+
+  test("should show category badges on items", async ({ page }) => {
+    await page.goto("/shopping");
+    await dismissUserPickerIfVisible(page);
+    await page.waitForLoadState("networkidle");
+
+    // Select our test list
+    const selectTrigger = page.locator("button[role='combobox']").first();
+    if (await selectTrigger.isVisible().catch(() => false)) {
+      await selectTrigger.click();
+      const listOption = page.getByRole("option", {
+        name: new RegExp(TEST_LIST_NAME),
+      });
+      if (await listOption.isVisible().catch(() => false)) {
+        await listOption.click();
+        await page.waitForLoadState("networkidle");
+      }
+    }
+
+    // Verify that category badges are rendered (small colored spans)
+    // The Bread item should have a "Bakery" badge
+    const breadRow = page
+      .locator("div.flex.items-center", { hasText: "Bread" })
+      .first();
+    const bakeryBadge = breadRow.locator("span.rounded-full", {
+      hasText: "Bakery",
+    });
+    await expect(bakeryBadge).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/src/app/api/__tests__/setup.test.ts
+++ b/src/app/api/__tests__/setup.test.ts
@@ -54,6 +54,7 @@ function createTables() {
       quantity TEXT,
       checked INTEGER DEFAULT 0,
       sort_order INTEGER DEFAULT 0,
+      category TEXT,
       added_by INTEGER REFERENCES users(id),
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );

--- a/src/app/api/__tests__/shopping-categories.test.ts
+++ b/src/app/api/__tests__/shopping-categories.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+// ─── In-memory DB wiring ────────────────────────────────────────────────────
+
+let testDb: ReturnType<typeof drizzle>;
+let sqlite: Database.Database;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+  schema,
+}));
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS shopping_lists (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      color TEXT DEFAULT '#3b82f6',
+      sort_order INTEGER DEFAULT 0,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE TABLE IF NOT EXISTS shopping_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      list_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      quantity TEXT,
+      checked INTEGER DEFAULT 0,
+      sort_order INTEGER DEFAULT 0,
+      category TEXT,
+      added_by INTEGER,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (list_id) REFERENCES shopping_lists(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS item_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      category TEXT,
+      use_count INTEGER DEFAULT 1,
+      last_used TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string, init?: RequestInit) {
+  return new Request(`http://localhost${url}`, init) as unknown as import("next/server").NextRequest;
+}
+
+function jsonBody(data: Record<string, unknown>): RequestInit {
+  return {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  };
+}
+
+function putBody(data: Record<string, unknown>): RequestInit {
+  return {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  };
+}
+
+function makeParams(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+function insertList(name: string, color = "#3b82f6") {
+  return sqlite
+    .prepare("INSERT INTO shopping_lists (name, color) VALUES (?, ?)")
+    .run(name, color);
+}
+
+function insertItem(
+  listId: number,
+  name: string,
+  extra: Record<string, unknown> = {}
+) {
+  const cols = ["list_id", "name", ...Object.keys(extra)];
+  const vals = [listId, name, ...Object.values(extra)];
+  const placeholders = cols.map(() => "?").join(", ");
+  return sqlite
+    .prepare(
+      `INSERT INTO shopping_items (${cols.join(", ")}) VALUES (${placeholders})`
+    )
+    .run(...vals);
+}
+
+function insertItemHistory(
+  name: string,
+  extra: Record<string, unknown> = {}
+) {
+  const cols = ["name", ...Object.keys(extra)];
+  const vals = [name, ...Object.values(extra)];
+  const placeholders = cols.map(() => "?").join(", ");
+  return sqlite
+    .prepare(
+      `INSERT INTO item_history (${cols.join(", ")}) VALUES (${placeholders})`
+    )
+    .run(...vals);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PURE CATEGORIZATION LOGIC
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("categorizeItem()", () => {
+  let categorizeItem: typeof import("@/lib/shopping-categories").categorizeItem;
+  let getCategorySortOrder: typeof import("@/lib/shopping-categories").getCategorySortOrder;
+  let getCategoryByName: typeof import("@/lib/shopping-categories").getCategoryByName;
+  let SHOPPING_CATEGORIES: typeof import("@/lib/shopping-categories").SHOPPING_CATEGORIES;
+
+  beforeEach(async () => {
+    const mod = await import("@/lib/shopping-categories");
+    categorizeItem = mod.categorizeItem;
+    getCategorySortOrder = mod.getCategorySortOrder;
+    getCategoryByName = mod.getCategoryByName;
+    SHOPPING_CATEGORIES = mod.SHOPPING_CATEGORIES;
+  });
+
+  it("categorizes dairy items", () => {
+    expect(categorizeItem("Milk")).toBe("Dairy");
+    expect(categorizeItem("cheddar cheese")).toBe("Dairy");
+    expect(categorizeItem("BUTTER")).toBe("Dairy");
+    expect(categorizeItem("eggs")).toBe("Dairy");
+  });
+
+  it("categorizes produce items", () => {
+    expect(categorizeItem("banana")).toBe("Produce");
+    expect(categorizeItem("Red Onion")).toBe("Produce");
+    expect(categorizeItem("baby spinach")).toBe("Produce");
+  });
+
+  it("categorizes bakery items", () => {
+    expect(categorizeItem("bread")).toBe("Bakery");
+    expect(categorizeItem("Sourdough Bread")).toBe("Bakery");
+    expect(categorizeItem("bagels")).toBe("Bakery");
+  });
+
+  it("categorizes meat & seafood items", () => {
+    expect(categorizeItem("chicken breast")).toBe("Meat & Seafood");
+    expect(categorizeItem("salmon fillets")).toBe("Meat & Seafood");
+    expect(categorizeItem("beef mince")).toBe("Meat & Seafood");
+  });
+
+  it("categorizes pantry items", () => {
+    expect(categorizeItem("rice")).toBe("Pantry");
+    expect(categorizeItem("olive oil")).toBe("Pantry");
+    expect(categorizeItem("pasta")).toBe("Pantry");
+  });
+
+  it("categorizes drinks", () => {
+    expect(categorizeItem("orange juice")).toBe("Drinks");
+    expect(categorizeItem("coffee")).toBe("Drinks");
+    expect(categorizeItem("sparkling water")).toBe("Drinks");
+  });
+
+  it("categorizes household items", () => {
+    expect(categorizeItem("toilet paper")).toBe("Household");
+    expect(categorizeItem("dish detergent")).toBe("Household");
+    expect(categorizeItem("sponge")).toBe("Household");
+  });
+
+  it("categorizes frozen items", () => {
+    expect(categorizeItem("ice cream")).toBe("Frozen");
+    expect(categorizeItem("frozen peas")).toBe("Frozen");
+    expect(categorizeItem("fish fingers")).toBe("Frozen");
+  });
+
+  it("returns null for unknown items", () => {
+    expect(categorizeItem("unicorn dust")).toBeNull();
+    expect(categorizeItem("something random")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(categorizeItem("MILK")).toBe("Dairy");
+    expect(categorizeItem("Milk")).toBe("Dairy");
+    expect(categorizeItem("milk")).toBe("Dairy");
+  });
+
+  it("matches multi-word keywords before single words", () => {
+    // "sweet potato" should match Produce, not just "potato"
+    expect(categorizeItem("sweet potato")).toBe("Produce");
+    // "soy sauce" should match Pantry
+    expect(categorizeItem("soy sauce")).toBe("Pantry");
+    // "ice cream" should match Frozen
+    expect(categorizeItem("ice cream")).toBe("Frozen");
+  });
+
+  it("getCategorySortOrder returns correct orders", () => {
+    expect(getCategorySortOrder("Produce")).toBe(0);
+    expect(getCategorySortOrder("Dairy")).toBe(1);
+    expect(getCategorySortOrder("Other")).toBe(8);
+    expect(getCategorySortOrder(null)).toBe(999);
+    expect(getCategorySortOrder("Unknown")).toBe(999);
+  });
+
+  it("getCategoryByName finds categories", () => {
+    const dairy = getCategoryByName("Dairy");
+    expect(dairy).toBeDefined();
+    expect(dairy?.color).toBe("#3b82f6");
+    expect(getCategoryByName("nonexistent")).toBeUndefined();
+  });
+
+  it("SHOPPING_CATEGORIES has correct count", () => {
+    expect(SHOPPING_CATEGORIES).toHaveLength(9);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// API: POST /api/shopping/items
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Shopping Items API - Category", () => {
+  let itemsRoute: typeof import("@/app/api/shopping/items/route");
+
+  beforeEach(async () => {
+    itemsRoute = await import("@/app/api/shopping/items/route");
+  });
+
+  it("auto-categorizes known items on POST", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ listId, name: "Milk" })
+    );
+    const res = await itemsRoute.POST(req);
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+
+    // Verify in DB
+    const row = sqlite
+      .prepare("SELECT category FROM shopping_items WHERE id = ?")
+      .get(Number(data.id)) as Record<string, unknown>;
+    expect(row.category).toBe("Dairy");
+  });
+
+  it("stores category as null for unknown items", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ listId, name: "unicorn dust" })
+    );
+    const res = await itemsRoute.POST(req);
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    const row = sqlite
+      .prepare("SELECT category FROM shopping_items WHERE id = ?")
+      .get(Number(data.id)) as Record<string, unknown>;
+    expect(row.category).toBeNull();
+  });
+
+  it("accepts explicit category override", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ listId, name: "Milk", category: "Pantry" })
+    );
+    const res = await itemsRoute.POST(req);
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    const row = sqlite
+      .prepare("SELECT category FROM shopping_items WHERE id = ?")
+      .get(Number(data.id)) as Record<string, unknown>;
+    expect(row.category).toBe("Pantry");
+  });
+
+  it("uses category from item history when available", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+
+    // Pre-populate item history with a custom category
+    insertItemHistory("special item", { category: "Frozen" });
+
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ listId, name: "Special Item" })
+    );
+    const res = await itemsRoute.POST(req);
+
+    expect(res.status).toBe(201);
+    const data = await res.json();
+
+    const row = sqlite
+      .prepare("SELECT category FROM shopping_items WHERE id = ?")
+      .get(Number(data.id)) as Record<string, unknown>;
+    expect(row.category).toBe("Frozen");
+  });
+
+  it("saves category to item history on POST", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ listId, name: "Bread" })
+    );
+    await itemsRoute.POST(req);
+
+    // Check item_history
+    const historyRow = sqlite
+      .prepare("SELECT category FROM item_history WHERE name = ?")
+      .get("bread") as Record<string, unknown>;
+    expect(historyRow.category).toBe("Bakery");
+  });
+
+  it("updates item history category on repeated adds", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+
+    // First add - auto-categorized
+    await itemsRoute.POST(
+      makeRequest(
+        "/api/shopping/items",
+        jsonBody({ listId, name: "Bread" })
+      )
+    );
+
+    // Second add - explicit override
+    await itemsRoute.POST(
+      makeRequest(
+        "/api/shopping/items",
+        jsonBody({ listId, name: "Bread", category: "Other" })
+      )
+    );
+
+    const historyRow = sqlite
+      .prepare("SELECT category, use_count FROM item_history WHERE name = ?")
+      .get("bread") as Record<string, unknown>;
+    expect(historyRow.category).toBe("Other");
+    expect(historyRow.use_count).toBe(2);
+  });
+
+  it("returns 400 when listId is missing", async () => {
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ name: "Milk" })
+    );
+    const res = await itemsRoute.POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when name is missing", async () => {
+    const req = makeRequest(
+      "/api/shopping/items",
+      jsonBody({ listId: 1 })
+    );
+    const res = await itemsRoute.POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// API: PUT /api/shopping/items/[id] - category update
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Shopping Items API - Category Update", () => {
+  let itemsIdRoute: typeof import("@/app/api/shopping/items/[id]/route");
+
+  beforeEach(async () => {
+    itemsIdRoute = await import("@/app/api/shopping/items/[id]/route");
+  });
+
+  it("updates item category via PUT", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+    const itemResult = insertItem(listId, "Mystery Item", { category: null });
+    const itemId = String(itemResult.lastInsertRowid);
+
+    const req = makeRequest(
+      `/api/shopping/items/${itemId}`,
+      putBody({ category: "Dairy" })
+    );
+    const res = await itemsIdRoute.PUT(req, makeParams(itemId));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+
+    const row = sqlite
+      .prepare("SELECT category FROM shopping_items WHERE id = ?")
+      .get(itemId) as Record<string, unknown>;
+    expect(row.category).toBe("Dairy");
+  });
+
+  it("returns 404 for non-existent item", async () => {
+    const req = makeRequest(
+      "/api/shopping/items/999",
+      putBody({ category: "Dairy" })
+    );
+    const res = await itemsIdRoute.PUT(req, makeParams("999"));
+    expect(res.status).toBe(404);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// API: GET /api/shopping/lists/[id] - items include category
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Shopping List GET - Category in items", () => {
+  let listsIdRoute: typeof import("@/app/api/shopping/lists/[id]/route");
+
+  beforeEach(async () => {
+    listsIdRoute = await import("@/app/api/shopping/lists/[id]/route");
+  });
+
+  it("returns items with category field", async () => {
+    const listResult = insertList("Groceries");
+    const listId = Number(listResult.lastInsertRowid);
+    insertItem(listId, "Milk", { category: "Dairy" });
+    insertItem(listId, "Bread", { category: "Bakery" });
+    insertItem(listId, "Unknown Thing");
+
+    const req = makeRequest(`/api/shopping/lists/${listId}`);
+    const res = await listsIdRoute.GET(req, makeParams(String(listId)));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.items).toHaveLength(3);
+    expect(data.items[0].category).toBe("Dairy");
+    expect(data.items[1].category).toBe("Bakery");
+    expect(data.items[2].category).toBeNull();
+  });
+});

--- a/src/app/api/setup/route.ts
+++ b/src/app/api/setup/route.ts
@@ -8,6 +8,7 @@ import {
   recipes,
   recipeIngredients,
 } from "@/lib/db/schema";
+import { categorizeItem } from "@/lib/shopping-categories";
 
 export const dynamic = "force-dynamic";
 
@@ -168,9 +169,11 @@ export async function POST(request: Request) {
       const listId = Number(listResult.lastInsertRowid);
 
       for (let i = 0; i < STARTER_SHOPPING_ITEMS.length; i++) {
+        const itemName = STARTER_SHOPPING_ITEMS[i];
         await db.insert(shoppingItems).values({
           listId,
-          name: STARTER_SHOPPING_ITEMS[i],
+          name: itemName,
+          category: categorizeItem(itemName),
           sortOrder: i,
         });
       }

--- a/src/app/api/shopping/items/route.ts
+++ b/src/app/api/shopping/items/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { shoppingItems, itemHistory } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { validateApiRequest } from "@/lib/auth/validate";
+import { categorizeItem } from "@/lib/shopping-categories";
 
 export async function POST(request: Request) {
   try {
@@ -10,7 +11,7 @@ export async function POST(request: Request) {
     if (authError) return authError;
 
     const body = await request.json();
-    const { listId, name, quantity, addedBy } = body;
+    const { listId, name, quantity, addedBy, category: explicitCategory } = body;
 
     if (!listId || !name) {
       return NextResponse.json(
@@ -19,29 +20,51 @@ export async function POST(request: Request) {
       );
     }
 
+    // Resolve category: explicit > history > auto-detect
+    const normalizedName = name.trim().toLowerCase();
+    let resolvedCategory: string | null = explicitCategory || null;
+
+    if (!resolvedCategory) {
+      // Check item history for a previously stored category
+      const historyRows = await db
+        .select({ category: itemHistory.category })
+        .from(itemHistory)
+        .where(eq(itemHistory.name, normalizedName))
+        .limit(1);
+      if (historyRows.length > 0 && historyRows[0].category) {
+        resolvedCategory = historyRows[0].category;
+      }
+    }
+
+    if (!resolvedCategory) {
+      resolvedCategory = categorizeItem(name.trim());
+    }
+
     // Add item to list
     const result = await db.insert(shoppingItems).values({
       listId,
       name: name.trim(),
       quantity: quantity || null,
+      category: resolvedCategory,
       addedBy: addedBy || null,
     });
 
-    // Update item history for autocomplete
-    const normalizedName = name.trim().toLowerCase();
+    // Update item history for autocomplete (including category)
     try {
       await db.insert(itemHistory).values({
         name: normalizedName,
+        category: resolvedCategory,
         useCount: 1,
         lastUsed: new Date().toISOString(),
       });
     } catch {
-      // Item already exists, update count
+      // Item already exists, update count and category
       await db
         .update(itemHistory)
         .set({
           useCount: sql`${itemHistory.useCount} + 1`,
           lastUsed: new Date().toISOString(),
+          ...(resolvedCategory ? { category: resolvedCategory } : {}),
         })
         .where(eq(itemHistory.name, normalizedName));
     }

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -15,6 +15,11 @@ import { Plus, Trash2, Pencil, ShoppingCart, Check } from "lucide-react";
 import { AddItemInput } from "@/components/shopping/AddItemInput";
 import { ListForm } from "@/components/shopping/ListForm";
 import { AppLayout } from "@/components/layout/AppLayout";
+import {
+  SHOPPING_CATEGORIES,
+  getCategorySortOrder,
+  getCategoryByName,
+} from "@/lib/shopping-categories";
 
 interface ShoppingList {
   id: number;
@@ -31,7 +36,36 @@ interface ShoppingItem {
   quantity: string | null;
   checked: boolean;
   sortOrder: number;
+  category: string | null;
   createdAt: string | null;
+}
+
+interface CategoryGroup {
+  name: string;
+  color: string;
+  items: ShoppingItem[];
+}
+
+function groupItemsByCategory(items: ShoppingItem[]): CategoryGroup[] {
+  const groups: Record<string, ShoppingItem[]> = {};
+  for (const item of items) {
+    const cat = item.category || "Uncategorised";
+    if (!groups[cat]) groups[cat] = [];
+    groups[cat].push(item);
+  }
+
+  return Object.entries(groups)
+    .map(([name, groupItems]) => {
+      const catInfo = getCategoryByName(name);
+      return {
+        name,
+        color: catInfo?.color || "#6b7280",
+        items: groupItems,
+      };
+    })
+    .sort(
+      (a, b) => getCategorySortOrder(a.name) - getCategorySortOrder(b.name)
+    );
 }
 
 export default function ShoppingPage() {
@@ -176,9 +210,28 @@ export default function ShoppingPage() {
     }
   };
 
+  const handleUpdateCategory = async (id: number, category: string) => {
+    try {
+      const response = await fetch(`/api/shopping/items/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ category }),
+      });
+
+      if (response.ok) {
+        setItems((prev) =>
+          prev.map((item) => (item.id === id ? { ...item, category } : item))
+        );
+      }
+    } catch (error) {
+      console.error("Error updating category:", error);
+    }
+  };
+
   const checkedCount = items.filter((i) => i.checked).length;
   const uncheckedItems = items.filter((i) => !i.checked);
   const checkedItems = items.filter((i) => i.checked);
+  const uncheckedGroups = groupItemsByCategory(uncheckedItems);
 
   return (
     <AppLayout title="Shopping Lists">
@@ -292,66 +345,132 @@ export default function ShoppingPage() {
                     No items yet. Add something above!
                   </p>
                 ) : (
-                  <div className="space-y-2">
-                    {/* Unchecked items first */}
-                    {uncheckedItems.map((item) => (
-                      <div
-                        key={item.id}
-                        className="flex items-center gap-3 p-3 bg-white dark:bg-zinc-900 rounded-lg border group"
-                      >
-                        <Checkbox
-                          checked={item.checked}
-                          onCheckedChange={(checked) =>
-                            handleToggleItem(item.id, checked as boolean)
-                          }
-                        />
-                        <div className="flex-1 min-w-0">
-                          {item.quantity && (
-                            <span className="font-medium text-blue-600 mr-2">
-                              {item.quantity}
-                            </span>
-                          )}
-                          {item.name}
+                  <div className="space-y-4">
+                    {/* Unchecked items grouped by category */}
+                    {uncheckedGroups.map((group) => (
+                      <div key={group.name} data-testid={`category-group-${group.name}`}>
+                        <div className="flex items-center gap-2 mb-2">
+                          <div
+                            className="w-3 h-3 rounded-full"
+                            style={{ backgroundColor: group.color }}
+                          />
+                          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                            {group.name}
+                          </h3>
+                          <span className="text-xs text-muted-foreground">
+                            ({group.items.length})
+                          </span>
                         </div>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
-                          onClick={() => handleDeleteItem(item.id)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+                        <div className="space-y-2">
+                          {group.items.map((item) => (
+                            <div
+                              key={item.id}
+                              className="flex items-center gap-3 p-3 bg-white dark:bg-zinc-900 rounded-lg border group"
+                            >
+                              <Checkbox
+                                checked={item.checked}
+                                onCheckedChange={(checked) =>
+                                  handleToggleItem(item.id, checked as boolean)
+                                }
+                              />
+                              <div className="flex-1 min-w-0">
+                                {item.quantity && (
+                                  <span className="font-medium text-blue-600 mr-2">
+                                    {item.quantity}
+                                  </span>
+                                )}
+                                {item.name}
+                                {item.category && (
+                                  <span
+                                    className="ml-2 inline-block text-xs px-1.5 py-0.5 rounded-full text-white"
+                                    style={{
+                                      backgroundColor:
+                                        getCategoryByName(item.category)?.color || "#6b7280",
+                                    }}
+                                  >
+                                    {item.category}
+                                  </span>
+                                )}
+                              </div>
+                              <Select
+                                value={item.category || ""}
+                                onValueChange={(value) =>
+                                  handleUpdateCategory(item.id, value)
+                                }
+                              >
+                                <SelectTrigger className="w-[130px] h-8 text-xs opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity">
+                                  <SelectValue placeholder="Category" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {SHOPPING_CATEGORIES.map((cat) => (
+                                    <SelectItem key={cat.id} value={cat.name}>
+                                      <div className="flex items-center gap-2">
+                                        <div
+                                          className="w-2 h-2 rounded-full"
+                                          style={{ backgroundColor: cat.color }}
+                                        />
+                                        {cat.name}
+                                      </div>
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
+                                onClick={() => handleDeleteItem(item.id)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
                       </div>
                     ))}
 
                     {/* Checked items with strikethrough */}
-                    {checkedItems.map((item) => (
-                      <div
-                        key={item.id}
-                        className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-zinc-800 rounded-lg border opacity-60 group"
-                      >
-                        <Checkbox
-                          checked={item.checked}
-                          onCheckedChange={(checked) =>
-                            handleToggleItem(item.id, checked as boolean)
-                          }
-                        />
-                        <div className="flex-1 min-w-0 line-through text-muted-foreground">
-                          {item.quantity && (
-                            <span className="mr-2">{item.quantity}</span>
-                          )}
-                          {item.name}
+                    {checkedItems.length > 0 && (
+                      <div>
+                        <div className="flex items-center gap-2 mb-2">
+                          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                            Checked
+                          </h3>
+                          <span className="text-xs text-muted-foreground">
+                            ({checkedItems.length})
+                          </span>
                         </div>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
-                          onClick={() => handleDeleteItem(item.id)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
+                        <div className="space-y-2">
+                          {checkedItems.map((item) => (
+                            <div
+                              key={item.id}
+                              className="flex items-center gap-3 p-3 bg-gray-50 dark:bg-zinc-800 rounded-lg border opacity-60 group"
+                            >
+                              <Checkbox
+                                checked={item.checked}
+                                onCheckedChange={(checked) =>
+                                  handleToggleItem(item.id, checked as boolean)
+                                }
+                              />
+                              <div className="flex-1 min-w-0 line-through text-muted-foreground">
+                                {item.quantity && (
+                                  <span className="mr-2">{item.quantity}</span>
+                                )}
+                                {item.name}
+                              </div>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="text-red-500 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950 opacity-0 group-hover:opacity-100 transition-opacity"
+                                onClick={() => handleDeleteItem(item.id)}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                    ))}
+                    )}
                   </div>
                 )}
               </CardContent>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -316,6 +316,16 @@ function initDb(): BetterSQLite3Database<typeof schema> {
     sqlite.exec(`ALTER TABLE recipe_ingredients ADD COLUMN section TEXT`);
   } catch { /* column already exists */ }
 
+  // Shopping item category
+  try {
+    sqlite.exec(`ALTER TABLE shopping_items ADD COLUMN category TEXT`);
+  } catch { /* column already exists */ }
+
+  // Item history category
+  try {
+    sqlite.exec(`ALTER TABLE item_history ADD COLUMN category TEXT`);
+  } catch { /* column already exists */ }
+
   // Migrate legacy quantity strings to structured amount+unit
   migrateLegacyQuantities(sqlite);
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -76,6 +76,7 @@ export const shoppingItems = sqliteTable("shopping_items", {
   quantity: text("quantity"),
   checked: integer("checked", { mode: "boolean" }).default(false),
   sortOrder: integer("sort_order").default(0),
+  category: text("category"),
   addedBy: integer("added_by").references(() => users.id),
   createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
 });
@@ -83,6 +84,7 @@ export const shoppingItems = sqliteTable("shopping_items", {
 export const itemHistory = sqliteTable("item_history", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   name: text("name").notNull().unique(),
+  category: text("category"),
   useCount: integer("use_count").default(1),
   lastUsed: text("last_used").default("CURRENT_TIMESTAMP"),
 });

--- a/src/lib/shopping-categories.ts
+++ b/src/lib/shopping-categories.ts
@@ -1,0 +1,280 @@
+export interface ShoppingCategory {
+  id: string;
+  name: string;
+  color: string;
+  sortOrder: number;
+}
+
+export const SHOPPING_CATEGORIES: ShoppingCategory[] = [
+  { id: "produce", name: "Produce", color: "#22c55e", sortOrder: 0 },
+  { id: "dairy", name: "Dairy", color: "#3b82f6", sortOrder: 1 },
+  { id: "meat-seafood", name: "Meat & Seafood", color: "#ef4444", sortOrder: 2 },
+  { id: "bakery", name: "Bakery", color: "#f59e0b", sortOrder: 3 },
+  { id: "frozen", name: "Frozen", color: "#06b6d4", sortOrder: 4 },
+  { id: "pantry", name: "Pantry", color: "#8b5cf6", sortOrder: 5 },
+  { id: "drinks", name: "Drinks", color: "#f97316", sortOrder: 6 },
+  { id: "household", name: "Household", color: "#ec4899", sortOrder: 7 },
+  { id: "other", name: "Other", color: "#6b7280", sortOrder: 8 },
+];
+
+/**
+ * Map of keywords to category names.
+ * Keys are lowercase substrings that will be matched against item names.
+ */
+const CATEGORY_ITEM_MAP: Record<string, string> = {
+  // Produce
+  apple: "Produce",
+  banana: "Produce",
+  lettuce: "Produce",
+  tomato: "Produce",
+  onion: "Produce",
+  carrot: "Produce",
+  potato: "Produce",
+  garlic: "Produce",
+  lemon: "Produce",
+  lime: "Produce",
+  avocado: "Produce",
+  cucumber: "Produce",
+  spinach: "Produce",
+  broccoli: "Produce",
+  capsicum: "Produce",
+  pepper: "Produce",
+  celery: "Produce",
+  mushroom: "Produce",
+  zucchini: "Produce",
+  corn: "Produce",
+  pumpkin: "Produce",
+  "sweet potato": "Produce",
+  ginger: "Produce",
+  herbs: "Produce",
+  basil: "Produce",
+  coriander: "Produce",
+  parsley: "Produce",
+  mint: "Produce",
+  strawberr: "Produce",
+  blueberr: "Produce",
+  raspberr: "Produce",
+  grape: "Produce",
+  pear: "Produce",
+  watermelon: "Produce",
+  mango: "Produce",
+  pineapple: "Produce",
+  kiwi: "Produce",
+  peach: "Produce",
+  plum: "Produce",
+  cherry: "Produce",
+  beetroot: "Produce",
+  cabbage: "Produce",
+  cauliflower: "Produce",
+  eggplant: "Produce",
+  asparagus: "Produce",
+  "bean sprout": "Produce",
+  "spring onion": "Produce",
+  shallot: "Produce",
+  radish: "Produce",
+  kale: "Produce",
+  rocket: "Produce",
+
+  // Dairy
+  milk: "Dairy",
+  cheese: "Dairy",
+  butter: "Dairy",
+  yogurt: "Dairy",
+  yoghurt: "Dairy",
+  cream: "Dairy",
+  egg: "Dairy",
+  "sour cream": "Dairy",
+  "cottage cheese": "Dairy",
+  feta: "Dairy",
+  mozzarella: "Dairy",
+  parmesan: "Dairy",
+  cheddar: "Dairy",
+  brie: "Dairy",
+  camembert: "Dairy",
+
+  // Meat & Seafood
+  chicken: "Meat & Seafood",
+  beef: "Meat & Seafood",
+  pork: "Meat & Seafood",
+  fish: "Meat & Seafood",
+  salmon: "Meat & Seafood",
+  shrimp: "Meat & Seafood",
+  prawn: "Meat & Seafood",
+  mince: "Meat & Seafood",
+  lamb: "Meat & Seafood",
+  steak: "Meat & Seafood",
+  sausage: "Meat & Seafood",
+  bacon: "Meat & Seafood",
+  ham: "Meat & Seafood",
+  turkey: "Meat & Seafood",
+  tuna: "Meat & Seafood",
+  crab: "Meat & Seafood",
+  mussel: "Meat & Seafood",
+  oyster: "Meat & Seafood",
+  calamari: "Meat & Seafood",
+  squid: "Meat & Seafood",
+
+  // Bakery
+  bread: "Bakery",
+  roll: "Bakery",
+  bagel: "Bakery",
+  muffin: "Bakery",
+  croissant: "Bakery",
+  wrap: "Bakery",
+  pita: "Bakery",
+  bun: "Bakery",
+  sourdough: "Bakery",
+  "rye bread": "Bakery",
+  brioche: "Bakery",
+  crumpet: "Bakery",
+  scone: "Bakery",
+
+  // Frozen
+  "ice cream": "Frozen",
+  "frozen pea": "Frozen",
+  "frozen pizza": "Frozen",
+  "fish finger": "Frozen",
+  "frozen chip": "Frozen",
+  "frozen berr": "Frozen",
+  "frozen veg": "Frozen",
+  "frozen meal": "Frozen",
+  gelato: "Frozen",
+  sorbet: "Frozen",
+
+  // Pantry
+  rice: "Pantry",
+  pasta: "Pantry",
+  flour: "Pantry",
+  sugar: "Pantry",
+  salt: "Pantry",
+  oil: "Pantry",
+  vinegar: "Pantry",
+  sauce: "Pantry",
+  canned: "Pantry",
+  cereal: "Pantry",
+  oat: "Pantry",
+  noodle: "Pantry",
+  spice: "Pantry",
+  "black pepper": "Pantry",
+  cumin: "Pantry",
+  paprika: "Pantry",
+  cinnamon: "Pantry",
+  honey: "Pantry",
+  jam: "Pantry",
+  "peanut butter": "Pantry",
+  nutella: "Pantry",
+  vegemite: "Pantry",
+  "soy sauce": "Pantry",
+  "tomato paste": "Pantry",
+  stock: "Pantry",
+  broth: "Pantry",
+  "baking powder": "Pantry",
+  "baking soda": "Pantry",
+  yeast: "Pantry",
+  "coconut milk": "Pantry",
+  chickpea: "Pantry",
+  lentil: "Pantry",
+  bean: "Pantry",
+  tin: "Pantry",
+  cracker: "Pantry",
+  chip: "Pantry",
+  crisp: "Pantry",
+  nut: "Pantry",
+  almond: "Pantry",
+  walnut: "Pantry",
+  cashew: "Pantry",
+  chocolate: "Pantry",
+  biscuit: "Pantry",
+  cookie: "Pantry",
+  snack: "Pantry",
+
+  // Drinks
+  water: "Drinks",
+  juice: "Drinks",
+  soda: "Drinks",
+  coffee: "Drinks",
+  tea: "Drinks",
+  wine: "Drinks",
+  beer: "Drinks",
+  kombucha: "Drinks",
+  cordial: "Drinks",
+  "soft drink": "Drinks",
+  "sparkling water": "Drinks",
+  "energy drink": "Drinks",
+  "coconut water": "Drinks",
+
+  // Household
+  soap: "Household",
+  detergent: "Household",
+  "toilet paper": "Household",
+  "paper towel": "Household",
+  "trash bag": "Household",
+  "bin liner": "Household",
+  sponge: "Household",
+  dishwash: "Household",
+  laundry: "Household",
+  bleach: "Household",
+  disinfectant: "Household",
+  cleaner: "Household",
+  shampoo: "Household",
+  conditioner: "Household",
+  toothpaste: "Household",
+  toothbrush: "Household",
+  deodorant: "Household",
+  tissue: "Household",
+  "glad wrap": "Household",
+  "cling wrap": "Household",
+  "aluminium foil": "Household",
+  "aluminum foil": "Household",
+  foil: "Household",
+  ziplock: "Household",
+  candle: "Household",
+  battery: "Household",
+  "light bulb": "Household",
+};
+
+// Sort keywords longest-first so multi-word phrases match before single words
+// (e.g. "sweet potato" before "potato", "soy sauce" before "sauce")
+const SORTED_KEYWORDS = Object.keys(CATEGORY_ITEM_MAP).sort(
+  (a, b) => b.length - a.length
+);
+
+// Build regex patterns for each keyword: use word boundaries to prevent
+// partial matches (e.g. "corn" should not match "unicorn").
+const KEYWORD_PATTERNS = SORTED_KEYWORDS.map((keyword) => ({
+  keyword,
+  pattern: new RegExp(`\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i"),
+}));
+
+/**
+ * Auto-categorize a shopping item by name.
+ * Returns the category name if a match is found, or null.
+ */
+export function categorizeItem(name: string): string | null {
+  const lower = name.toLowerCase().trim();
+  for (const { keyword, pattern } of KEYWORD_PATTERNS) {
+    if (pattern.test(lower)) {
+      return CATEGORY_ITEM_MAP[keyword];
+    }
+  }
+  return null;
+}
+
+/**
+ * Get a category object by name.
+ */
+export function getCategoryByName(name: string): ShoppingCategory | undefined {
+  return SHOPPING_CATEGORIES.find(
+    (c) => c.name.toLowerCase() === name.toLowerCase()
+  );
+}
+
+/**
+ * Get the sort order for a category name.
+ * Returns a high number for unknown categories so they sort last.
+ */
+export function getCategorySortOrder(categoryName: string | null): number {
+  if (!categoryName) return 999;
+  const cat = getCategoryByName(categoryName);
+  return cat ? cat.sortOrder : 999;
+}


### PR DESCRIPTION
## Summary

- Add `category` column to `shopping_items` and `item_history` tables with ALTER TABLE migrations
- Create `src/lib/shopping-categories.ts` with 9 default categories (Produce, Dairy, Meat & Seafood, Bakery, Frozen, Pantry, Drinks, Household, Other) and a keyword-based auto-categorization function
- API auto-categorizes items on creation with a resolution chain: explicit category > item history > keyword auto-detect
- Shopping list UI groups unchecked items by category with colored section headers, category badges on items, and a hover-to-reveal dropdown for manual category override
- Setup seed auto-categorizes the starter shopping items
- 25 new unit tests covering categorization logic, API behavior, and category persistence
- E2E test for category grouping, badge rendering, and manual category change

Closes #40

## Test plan

- [x] `npm test` -- all 84 tests pass (25 new for shopping categories)
- [x] `npm run lint` -- 0 errors (all warnings pre-existing)
- [ ] `npm run test:e2e` -- run `shopping-categories.spec.ts` to verify category grouping, badge display, and manual category change in the browser
- [ ] Manual: add items like "milk", "bread", "chicken" and verify they auto-group under Dairy, Bakery, Meat & Seafood headers
- [ ] Manual: hover an item and use the category dropdown to reassign it; verify the item moves to the new group
- [ ] Manual: verify existing databases migrate cleanly (category columns added via ALTER TABLE)
