### PR TITLE
Add cook mode -- step-by-step kitchen display

### DIFF
--- a/e2e/cook-mode.spec.ts
+++ b/e2e/cook-mode.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect, Page } from "@playwright/test";
+import { cleanupTestData } from "./cleanup";
+
+const TEST_RECIPE_NAME = `E2E Cook Mode Recipe ${Date.now()}`;
+
+async function dismissUserPickerIfVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  const dialog = page.getByRole("dialog");
+  const isVisible = await dialog.isVisible().catch(() => false);
+  if (isVisible) {
+    const heading = dialog.getByRole("heading");
+    const text = await heading.textContent().catch(() => "");
+    if (text === "Who are you?" || text === "Switch User") {
+      const userButton = dialog.locator("button").first();
+      if (await userButton.isVisible().catch(() => false)) {
+        await userButton.click();
+        await expect(dialog).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+  }
+}
+
+test.afterAll(async ({ request }) => {
+  await cleanupTestData(request, "recipes", "E2E Cook Mode Recipe%");
+});
+
+test.describe.serial("Cook Mode", () => {
+  test("should create a recipe with multi-step instructions", async ({
+    page,
+  }) => {
+    await page.goto("/recipes");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.getByRole("button", { name: "New Recipe" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel("Recipe Name").fill(TEST_RECIPE_NAME);
+    await dialog.getByLabel("Description").fill("A test recipe for cook mode");
+    await dialog.getByLabel("Prep Time (min)").fill("5");
+    await dialog.getByLabel("Cook Time (min)").fill("15");
+    await dialog.getByLabel("Servings").fill("2");
+
+    const ingredientNameInputs = dialog.locator(
+      "input[placeholder='Ingredient name']"
+    );
+    await ingredientNameInputs.first().fill("Pasta");
+    const amountInputs = dialog.locator("input[placeholder='Amt']");
+    await amountInputs.first().fill("250");
+
+    const unitTriggers = dialog
+      .locator("button[role='combobox']")
+      .filter({ hasText: /Unit|g|kg|mL|L|cup|tbsp|tsp|whole/ });
+    await unitTriggers.first().click();
+    await page.getByRole("option", { name: "g", exact: true }).click();
+
+    await dialog
+      .getByLabel("Instructions")
+      .fill(
+        "Boil a large pot of water\nCook pasta for 10 minutes\nDrain and serve"
+      );
+
+    const responsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/recipes") &&
+        resp.request().method() === "POST"
+    );
+    await dialog.getByRole("button", { name: "Create Recipe" }).click();
+    await responsePromise;
+
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(TEST_RECIPE_NAME)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test("should open cook mode from recipe detail", async ({ page }) => {
+    await page.goto("/recipes");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Open recipe detail
+    await page.getByText(TEST_RECIPE_NAME).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Verify "Start Cooking" button is present
+    const startBtn = dialog.getByTestId("start-cooking");
+    await expect(startBtn).toBeVisible();
+
+    // Click "Start Cooking"
+    await startBtn.click();
+
+    // Cook mode overlay should be visible
+    const cookMode = page.getByTestId("cook-mode");
+    await expect(cookMode).toBeVisible({ timeout: 3000 });
+
+    // Should show recipe name
+    await expect(cookMode.getByText(TEST_RECIPE_NAME)).toBeVisible();
+
+    // Should show step 1 of 3
+    const stepCounter = cookMode.getByTestId("step-counter");
+    await expect(stepCounter).toHaveText("Step 1 of 3");
+
+    // Should show first step text
+    const stepText = cookMode.getByTestId("step-text");
+    await expect(stepText).toHaveText("Boil a large pot of water");
+  });
+
+  test("should navigate steps with next/previous buttons", async ({
+    page,
+  }) => {
+    await page.goto("/recipes");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Open recipe detail and cook mode
+    await page.getByText(TEST_RECIPE_NAME).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByTestId("start-cooking").click();
+
+    const cookMode = page.getByTestId("cook-mode");
+    await expect(cookMode).toBeVisible({ timeout: 3000 });
+
+    // Verify starting at step 1
+    await expect(cookMode.getByTestId("step-counter")).toHaveText(
+      "Step 1 of 3"
+    );
+
+    // Previous should be disabled on step 1
+    const prevBtn = cookMode.getByTestId("cook-mode-prev");
+    await expect(prevBtn).toBeDisabled();
+
+    // Click next
+    const nextBtn = cookMode.getByTestId("cook-mode-next");
+    await nextBtn.click();
+
+    // Should now be step 2
+    await expect(cookMode.getByTestId("step-counter")).toHaveText(
+      "Step 2 of 3"
+    );
+    await expect(cookMode.getByTestId("step-text")).toHaveText(
+      "Cook pasta for 10 minutes"
+    );
+
+    // Previous should now be enabled
+    await expect(prevBtn).toBeEnabled();
+
+    // Click next again to step 3
+    await nextBtn.click();
+    await expect(cookMode.getByTestId("step-counter")).toHaveText(
+      "Step 3 of 3"
+    );
+    await expect(cookMode.getByTestId("step-text")).toHaveText(
+      "Drain and serve"
+    );
+
+    // Next should be disabled on last step
+    await expect(nextBtn).toBeDisabled();
+
+    // Go back to step 2
+    await prevBtn.click();
+    await expect(cookMode.getByTestId("step-counter")).toHaveText(
+      "Step 2 of 3"
+    );
+  });
+
+  test("should show timer button on step with time reference", async ({
+    page,
+  }) => {
+    await page.goto("/recipes");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Open recipe detail and cook mode
+    await page.getByText(TEST_RECIPE_NAME).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByTestId("start-cooking").click();
+
+    const cookMode = page.getByTestId("cook-mode");
+    await expect(cookMode).toBeVisible({ timeout: 3000 });
+
+    // Navigate to step 2 which has "10 minutes"
+    await cookMode.getByTestId("cook-mode-next").click();
+    await expect(cookMode.getByTestId("step-counter")).toHaveText(
+      "Step 2 of 3"
+    );
+
+    // Should show a timer button
+    const timerBtn = cookMode.getByTestId("start-timer");
+    await expect(timerBtn).toBeVisible();
+    await expect(timerBtn).toContainText("10 minutes");
+  });
+
+  test("should close cook mode with close button", async ({ page }) => {
+    await page.goto("/recipes");
+    await dismissUserPickerIfVisible(page);
+    await expect(page.getByText("Loading recipes...")).not.toBeVisible({
+      timeout: 10000,
+    });
+
+    // Open recipe detail and cook mode
+    await page.getByText(TEST_RECIPE_NAME).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByTestId("start-cooking").click();
+
+    const cookMode = page.getByTestId("cook-mode");
+    await expect(cookMode).toBeVisible({ timeout: 3000 });
+
+    // Click close button
+    await cookMode.getByTestId("cook-mode-close").click();
+
+    // Cook mode should be gone
+    await expect(cookMode).not.toBeVisible({ timeout: 3000 });
+
+    // Recipe detail dialog should still be visible
+    await expect(dialog).toBeVisible();
+  });
+});

--- a/src/components/meals/CookMode.tsx
+++ b/src/components/meals/CookMode.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  X,
+  ChevronLeft,
+  ChevronRight,
+  Timer,
+  Pause,
+  Play,
+  ChefHat,
+} from "lucide-react";
+import {
+  IngredientUnit,
+  scaleAmount,
+  formatIngredient,
+} from "@/lib/ingredients";
+
+interface RecipeIngredient {
+  id: number;
+  recipeId: number;
+  name: string;
+  quantity: string | null;
+  amount: number | null;
+  unit: string | null;
+  section: string | null;
+  sortOrder: number;
+}
+
+interface CookModeProps {
+  recipeName: string;
+  instructions: string;
+  ingredients?: RecipeIngredient[];
+  multiplier: number;
+  onClose: () => void;
+}
+
+interface ParsedTimer {
+  seconds: number;
+  label: string;
+}
+
+/** Parse time references from step text, e.g. "simmer for 20 minutes" */
+function parseTimers(text: string): ParsedTimer[] {
+  const pattern = /(\d+)\s*(minutes?|mins?|hours?|hrs?|seconds?|secs?)/gi;
+  const timers: ParsedTimer[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    const value = parseInt(match[1], 10);
+    const unitRaw = match[2].toLowerCase();
+    let seconds: number;
+
+    if (unitRaw.startsWith("h")) {
+      seconds = value * 3600;
+    } else if (unitRaw.startsWith("s")) {
+      seconds = value;
+    } else {
+      seconds = value * 60;
+    }
+
+    timers.push({ seconds, label: `${match[1]} ${match[2]}` });
+  }
+
+  return timers;
+}
+
+function formatCountdown(totalSeconds: number): string {
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function StepTimer({ timer }: { timer: ParsedTimer }) {
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [running, setRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const start = useCallback(() => {
+    setRemaining(timer.seconds);
+    setRunning(true);
+  }, [timer.seconds]);
+
+  const togglePause = useCallback(() => {
+    setRunning((prev) => !prev);
+  }, []);
+
+  const reset = useCallback(() => {
+    setRemaining(null);
+    setRunning(false);
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (running && remaining !== null && remaining > 0) {
+      intervalRef.current = setInterval(() => {
+        setRemaining((prev) => {
+          if (prev === null || prev <= 1) {
+            setRunning(false);
+            // Vibrate on completion
+            if (typeof navigator !== "undefined" && navigator.vibrate) {
+              navigator.vibrate([200, 100, 200, 100, 200]);
+            }
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [running, remaining]);
+
+  if (remaining === null) {
+    return (
+      <Button
+        variant="outline"
+        size="touch"
+        className="border-amber-500/50 text-amber-400 hover:bg-amber-500/20 hover:text-amber-300 dark:border-amber-500/50 dark:text-amber-400 dark:hover:bg-amber-500/20"
+        onClick={start}
+        data-testid="start-timer"
+      >
+        <Timer className="h-5 w-5 mr-2" />
+        Start {timer.label} timer
+      </Button>
+    );
+  }
+
+  const done = remaining === 0;
+
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-lg px-4 py-3 ${
+        done
+          ? "bg-green-500/20 border border-green-500/50"
+          : "bg-amber-500/10 border border-amber-500/30"
+      }`}
+    >
+      <span
+        className={`font-mono text-2xl font-bold ${
+          done ? "text-green-400" : "text-amber-400"
+        }`}
+      >
+        {done ? "Done!" : formatCountdown(remaining)}
+      </span>
+      {!done && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-amber-400 hover:text-amber-300 hover:bg-amber-500/20"
+          onClick={togglePause}
+        >
+          {running ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="text-zinc-400 hover:text-zinc-300 hover:bg-zinc-700"
+        onClick={reset}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+export function CookMode({
+  recipeName,
+  instructions,
+  ingredients,
+  multiplier,
+  onClose,
+}: CookModeProps) {
+  const steps = instructions.split("\n").filter((l) => l.trim());
+  const [currentStep, setCurrentStep] = useState(0);
+  const touchStartX = useRef<number | null>(null);
+
+  // Wake Lock
+  useEffect(() => {
+    let sentinel: WakeLockSentinel | null = null;
+
+    async function requestWakeLock() {
+      try {
+        if ("wakeLock" in navigator) {
+          sentinel = await navigator.wakeLock.request("screen");
+        }
+      } catch {
+        // Wake Lock not available or denied — no-op
+      }
+    }
+
+    requestWakeLock();
+
+    return () => {
+      if (sentinel) {
+        sentinel.release().catch(() => {});
+      }
+    };
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setCurrentStep((prev) => Math.min(prev + 1, steps.length - 1));
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setCurrentStep((prev) => Math.max(prev - 1, 0));
+      } else if (e.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [steps.length, onClose]);
+
+  // Touch/swipe navigation
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      if (touchStartX.current === null) return;
+      const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+      const threshold = 50;
+
+      if (deltaX < -threshold) {
+        // Swipe left — next
+        setCurrentStep((prev) => Math.min(prev + 1, steps.length - 1));
+      } else if (deltaX > threshold) {
+        // Swipe right — previous
+        setCurrentStep((prev) => Math.max(prev - 1, 0));
+      }
+      touchStartX.current = null;
+    },
+    [steps.length]
+  );
+
+  const stepText = steps[currentStep] || "";
+  const timers = parseTimers(stepText);
+
+  // Match ingredients to current step
+  const matchedIngredients = (ingredients || []).filter((ing) =>
+    stepText.toLowerCase().includes(ing.name.toLowerCase())
+  );
+
+  const renderIngredientQty = (ing: RecipeIngredient) => {
+    if (ing.amount != null && ing.unit) {
+      const scaled = scaleAmount(
+        ing.amount,
+        ing.unit as IngredientUnit,
+        multiplier
+      );
+      return formatIngredient(scaled.amount, scaled.unit);
+    }
+    return ing.quantity || "";
+  };
+
+  const progressPercent = steps.length > 1
+    ? ((currentStep) / (steps.length - 1)) * 100
+    : 100;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-zinc-900 text-zinc-100 flex flex-col"
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      data-testid="cook-mode"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-700/50">
+        <div className="flex items-center gap-2 min-w-0">
+          <ChefHat className="h-5 w-5 text-amber-400 shrink-0" />
+          <h2 className="text-lg font-semibold truncate">{recipeName}</h2>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 shrink-0"
+          onClick={onClose}
+          data-testid="cook-mode-close"
+        >
+          <X className="h-6 w-6" />
+        </Button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1 bg-zinc-800">
+        <div
+          className="h-full bg-amber-500 transition-all duration-300"
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+
+      {/* Step counter */}
+      <div className="text-center py-3 text-zinc-400 text-sm" data-testid="step-counter">
+        Step {currentStep + 1} of {steps.length}
+      </div>
+
+      {/* Step content — scrollable center area */}
+      <div className="flex-1 overflow-y-auto px-6 pb-6 flex flex-col items-center justify-center">
+        <p className="text-2xl sm:text-3xl md:text-4xl leading-relaxed text-center max-w-2xl" data-testid="step-text">
+          {stepText}
+        </p>
+
+        {/* Matched ingredients for this step */}
+        {matchedIngredients.length > 0 && (
+          <div className="mt-8 w-full max-w-md">
+            <h3 className="text-sm font-medium text-zinc-400 mb-2 text-center">
+              Ingredients for this step
+            </h3>
+            <ul className="space-y-1">
+              {matchedIngredients.map((ing) => {
+                const qty = renderIngredientQty(ing);
+                return (
+                  <li
+                    key={ing.id}
+                    className="flex items-center justify-center gap-2 text-lg text-zinc-300"
+                  >
+                    {qty && (
+                      <span className="font-semibold text-amber-400">
+                        {qty}
+                      </span>
+                    )}
+                    <span>{ing.name}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        {/* Timers */}
+        {timers.length > 0 && (
+          <div className="mt-8 flex flex-col gap-3 items-center">
+            {timers.map((timer, i) => (
+              <StepTimer key={`${currentStep}-${i}`} timer={timer} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center justify-between px-4 py-4 border-t border-zinc-700/50">
+        <Button
+          variant="outline"
+          size="touch"
+          className="border-zinc-600 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          onClick={() => setCurrentStep((prev) => Math.max(prev - 1, 0))}
+          disabled={currentStep === 0}
+          data-testid="cook-mode-prev"
+        >
+          <ChevronLeft className="h-5 w-5 mr-1" />
+          Previous
+        </Button>
+
+        <Button
+          variant="outline"
+          size="touch"
+          className="border-zinc-600 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-700"
+          onClick={() =>
+            setCurrentStep((prev) => Math.min(prev + 1, steps.length - 1))
+          }
+          disabled={currentStep === steps.length - 1}
+          data-testid="cook-mode-next"
+        >
+          Next
+          <ChevronRight className="h-5 w-5 ml-1" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/meals/RecipeDetail.tsx
+++ b/src/components/meals/RecipeDetail.tsx
@@ -17,7 +17,9 @@ import {
   Copy,
   Printer,
   Check,
+  ChefHat,
 } from "lucide-react";
+import { CookMode } from "./CookMode";
 import { Recipe } from "./RecipeCard";
 import { resolveFileUrl } from "@/lib/file-url";
 import {
@@ -59,6 +61,7 @@ export function RecipeDetail({
 }: RecipeDetailProps) {
   const [multiplier, setMultiplier] = useState(1);
   const [copied, setCopied] = useState(false);
+  const [cookModeOpen, setCookModeOpen] = useState(false);
   const printRef = useRef<HTMLDivElement>(null);
 
   if (!recipe) return null;
@@ -232,6 +235,7 @@ export function RecipeDetail({
   };
 
   return (
+    <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
@@ -346,7 +350,7 @@ export function RecipeDetail({
           </div>
         )}
 
-        {/* Copy & Print buttons */}
+        {/* Copy, Print & Cook buttons */}
         <div className="flex gap-2">
           <Button variant="outline" size="sm" onClick={handleCopy}>
             {copied ? (
@@ -360,6 +364,17 @@ export function RecipeDetail({
             <Printer className="h-4 w-4 mr-1" />
             Print
           </Button>
+          {recipe.instructions && (
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => setCookModeOpen(true)}
+              data-testid="start-cooking"
+            >
+              <ChefHat className="h-4 w-4 mr-1" />
+              Start Cooking
+            </Button>
+          )}
         </div>
 
         <div className="flex justify-between items-center pt-4 border-t">
@@ -391,5 +406,16 @@ export function RecipeDetail({
         </div>
       </DialogContent>
     </Dialog>
+
+    {cookModeOpen && recipe.instructions && (
+      <CookMode
+        recipeName={recipe.name}
+        instructions={recipe.instructions}
+        ingredients={recipe.ingredients}
+        multiplier={multiplier}
+        onClose={() => setCookModeOpen(false)}
+      />
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Add full-screen cook mode overlay (`CookMode.tsx`) launched from RecipeDetail via "Start Cooking" button
- One instruction step at a time with large high-contrast text, step counter ("Step 3 of 8"), and progress bar
- Navigation via previous/next buttons, swipe gestures (touch), and keyboard arrows (left/right/escape)
- Wake Lock API integration to prevent screen timeout while cooking
- Inline countdown timers auto-detected from step text (e.g. "cook for 10 minutes") with start/pause/reset controls and vibration alert on completion
- Per-step ingredient display showing only ingredients mentioned in the current step, respecting the existing scale multiplier
- E2E test covering recipe creation, cook mode launch, step navigation, timer detection, and close behavior

## Test plan
- [ ] `npm test` -- all 59 unit tests pass (no new unit tests needed; this is a pure client component)
- [ ] `npm run lint` -- 0 errors (36 pre-existing warnings unchanged)
- [ ] `npm run test:e2e` -- new `e2e/cook-mode.spec.ts` with serial test group:
  - Creates a test recipe with 3-step instructions (one containing "10 minutes")
  - Opens cook mode from recipe detail and verifies step 1 of 3 displays
  - Navigates forward/backward and verifies step counter updates
  - Verifies timer button appears on step with time reference
  - Verifies close button exits cook mode back to recipe detail
  - Cleans up test data via `cleanupTestData`

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
