### PR TITLE
Add ability to delete fuel logs on vehicles

### DIFF
--- a/e2e/fuel-log-delete.spec.ts
+++ b/e2e/fuel-log-delete.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page } from "@playwright/test";
+import { cleanupTestData } from "./cleanup";
+
+const TEST_VEHICLE_NAME = `E2E Fuel Delete ${Date.now()}`;
+
+async function dismissUserPickerIfVisible(page: Page) {
+  await page.waitForLoadState("networkidle");
+  const dialog = page.getByRole("dialog");
+  const isVisible = await dialog.isVisible().catch(() => false);
+  if (isVisible) {
+    const heading = dialog.getByRole("heading");
+    const text = await heading.textContent().catch(() => "");
+    if (text === "Who are you?" || text === "Switch User") {
+      const userButton = dialog.locator("button").first();
+      if (await userButton.isVisible().catch(() => false)) {
+        await userButton.click();
+        await expect(dialog).not.toBeVisible({ timeout: 3000 });
+      }
+    }
+  }
+}
+
+test.afterAll(async ({ request }) => {
+  await cleanupTestData(request, "vehicles", "E2E Fuel Delete%");
+});
+
+test.describe("Fuel Log Delete", () => {
+  test.describe.serial("Delete fuel log from vehicle", () => {
+    test("should create a vehicle and add a fuel log", async ({ page }) => {
+      await page.goto("/vehicles");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading vehicles...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Create vehicle
+      await page.getByRole("button", { name: /Add.*Vehicle/ }).first().click();
+      const formDialog = page.getByRole("dialog");
+      await expect(formDialog).toBeVisible();
+
+      await formDialog.getByLabel("Name").fill(TEST_VEHICLE_NAME);
+
+      const createResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/vehicles") &&
+          resp.request().method() === "POST"
+      );
+      await formDialog.getByRole("button", { name: "Add Vehicle" }).click();
+      await createResponse;
+      await expect(formDialog).not.toBeVisible({ timeout: 5000 });
+      await page.waitForLoadState("networkidle");
+
+      // Open the vehicle detail
+      await page.getByText(TEST_VEHICLE_NAME).first().click();
+      const detailDialog = page.getByRole("dialog");
+      await expect(detailDialog).toBeVisible({ timeout: 5000 });
+
+      // Switch to Fuel tab
+      await detailDialog.getByRole("button", { name: "Fuel" }).click();
+
+      // Add a fuel log
+      await detailDialog.getByRole("button", { name: "Add Fuel" }).click();
+
+      // Fill the fuel form (it's inline, not a separate dialog)
+      await detailDialog.getByLabel("Date").fill("2026-01-15");
+      await detailDialog.getByLabel("Odometer (km)").fill("10000");
+      await detailDialog.getByLabel("Litres").fill("40");
+      await detailDialog.getByLabel("Total Cost ($)").fill("80");
+
+      const fuelResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/vehicles/") &&
+          resp.url().includes("/fuel") &&
+          resp.request().method() === "POST"
+      );
+      await detailDialog.getByRole("button", { name: "Save" }).click();
+      await fuelResponse;
+      await page.waitForLoadState("networkidle");
+
+      // Verify fuel log appears
+      await expect(detailDialog.getByText("$80.00").first()).toBeVisible({
+        timeout: 5000,
+      });
+    });
+
+    test("should delete the fuel log", async ({ page }) => {
+      await page.goto("/vehicles");
+      await dismissUserPickerIfVisible(page);
+      await expect(page.getByText("Loading vehicles...")).not.toBeVisible({
+        timeout: 10000,
+      });
+
+      // Open vehicle detail
+      await page.getByText(TEST_VEHICLE_NAME).first().click();
+      const detailDialog = page.getByRole("dialog");
+      await expect(detailDialog).toBeVisible({ timeout: 5000 });
+
+      // Switch to Fuel tab
+      await detailDialog.getByRole("button", { name: "Fuel" }).click();
+
+      // Verify fuel log is visible
+      await expect(detailDialog.getByText("$80.00").first()).toBeVisible({
+        timeout: 5000,
+      });
+
+      // Set up confirm dialog handler
+      page.on("dialog", async (d) => {
+        await d.accept();
+      });
+
+      // Click the delete (trash) button on the fuel log
+      const deleteResponse = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/fuel/") &&
+          resp.request().method() === "DELETE"
+      );
+      // The trash button is the icon button next to the cost badge
+      await detailDialog
+        .locator("button")
+        .filter({ has: page.locator("svg.lucide-trash-2") })
+        .first()
+        .click();
+      await deleteResponse;
+      await page.waitForLoadState("networkidle");
+
+      // Fuel log should be gone
+      await expect(
+        detailDialog.getByText("No fuel logs yet.")
+      ).toBeVisible({ timeout: 5000 });
+    });
+  });
+});

--- a/e2e/fuel-log-delete.spec.ts
+++ b/e2e/fuel-log-delete.spec.ts
@@ -58,14 +58,20 @@ test.describe("Fuel Log Delete", () => {
       // Switch to Fuel tab
       await detailDialog.getByRole("button", { name: "Fuel" }).click();
 
-      // Add a fuel log
+      // Open the inline fuel form
       await detailDialog.getByRole("button", { name: "Add Fuel" }).click();
 
-      // Fill the fuel form (it's inline, not a separate dialog)
-      await detailDialog.getByLabel("Date").fill("2026-01-15");
-      await detailDialog.getByLabel("Odometer (km)").fill("10000");
-      await detailDialog.getByLabel("Litres").fill("40");
-      await detailDialog.getByLabel("Total Cost ($)").fill("80");
+      // The form uses Label without htmlFor, so locate inputs by type
+      const fuelForm = detailDialog.locator("form");
+      await expect(fuelForm).toBeVisible({ timeout: 5000 });
+
+      const dateInput = fuelForm.locator('input[type="date"]');
+      await dateInput.fill("2026-01-15");
+
+      const numberInputs = fuelForm.locator('input[type="number"]');
+      await numberInputs.nth(0).fill("10000"); // Odometer
+      await numberInputs.nth(1).fill("40");    // Litres
+      await numberInputs.nth(2).fill("80");    // Total Cost
 
       const fuelResponse = page.waitForResponse(
         (resp) =>
@@ -73,7 +79,7 @@ test.describe("Fuel Log Delete", () => {
           resp.url().includes("/fuel") &&
           resp.request().method() === "POST"
       );
-      await detailDialog.getByRole("button", { name: "Save" }).click();
+      await fuelForm.getByRole("button", { name: "Add" }).click();
       await fuelResponse;
       await page.waitForLoadState("networkidle");
 

--- a/src/app/api/__tests__/fuel-log-delete.test.ts
+++ b/src/app/api/__tests__/fuel-log-delete.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+// ─── In-memory DB wiring ────────────────────────────────────────────────────
+
+let testDb: ReturnType<typeof drizzle>;
+let sqlite: Database.Database;
+
+vi.mock("@/lib/db", () => ({
+  get db() {
+    return testDb;
+  },
+  schema,
+}));
+
+function createTables() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS vehicles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      make TEXT,
+      model TEXT,
+      year INTEGER,
+      colour TEXT,
+      rego_number TEXT,
+      rego_state TEXT,
+      vin TEXT,
+      purchase_date TEXT,
+      purchase_price REAL,
+      current_odometer INTEGER,
+      image_url TEXT,
+      rego_expiry TEXT,
+      insurance_provider TEXT,
+      insurance_expiry TEXT,
+      warranty_expiry_date TEXT,
+      warranty_expiry_km INTEGER,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS fuel_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      vehicle_id INTEGER NOT NULL REFERENCES vehicles(id),
+      date TEXT NOT NULL,
+      odometer INTEGER NOT NULL,
+      litres REAL NOT NULL,
+      cost_total REAL NOT NULL,
+      cost_per_litre REAL,
+      station TEXT,
+      is_full_tank INTEGER DEFAULT 1,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+beforeEach(() => {
+  sqlite = new Database(":memory:");
+  testDb = drizzle(sqlite, { schema });
+  createTables();
+});
+
+afterEach(() => {
+  sqlite.close();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeRequest(url: string, method = "DELETE"): Request {
+  return new Request(`http://localhost${url}`, { method });
+}
+
+function insertVehicle(name = "Test Car"): number {
+  const result = sqlite
+    .prepare("INSERT INTO vehicles (name) VALUES (?)")
+    .run(name);
+  return Number(result.lastInsertRowid);
+}
+
+function insertFuelLog(vehicleId: number, date = "2026-01-15"): number {
+  const result = sqlite
+    .prepare(
+      `INSERT INTO fuel_logs (vehicle_id, date, odometer, litres, cost_total, cost_per_litre, is_full_tank)
+       VALUES (?, ?, 10000, 40, 80, 2.0, 1)`
+    )
+    .run(vehicleId, date);
+  return Number(result.lastInsertRowid);
+}
+
+function countFuelLogs(): number {
+  const row = sqlite
+    .prepare("SELECT COUNT(*) as count FROM fuel_logs")
+    .get() as { count: number };
+  return row.count;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FUEL LOG DELETE API
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Fuel Log Delete API", () => {
+  let fuelRoute: typeof import("@/app/api/vehicles/[id]/fuel/[fuelId]/route");
+
+  beforeEach(async () => {
+    fuelRoute = await import("@/app/api/vehicles/[id]/fuel/[fuelId]/route");
+  });
+
+  function callDelete(vehicleId: number, fuelId: number) {
+    const req = makeRequest(
+      `/api/vehicles/${vehicleId}/fuel/${fuelId}`,
+      "DELETE"
+    );
+    return fuelRoute.DELETE(req, {
+      params: Promise.resolve({
+        id: vehicleId.toString(),
+        fuelId: fuelId.toString(),
+      }),
+    });
+  }
+
+  it("deletes a fuel log successfully", async () => {
+    const vId = insertVehicle();
+    const fuelId = insertFuelLog(vId);
+    expect(countFuelLogs()).toBe(1);
+
+    const res = await callDelete(vId, fuelId);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(countFuelLogs()).toBe(0);
+  });
+
+  it("returns 404 for non-existent fuel log", async () => {
+    const vId = insertVehicle();
+
+    const res = await callDelete(vId, 999);
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toBe("Fuel log not found");
+  });
+
+  it("returns 404 when fuel log belongs to a different vehicle", async () => {
+    const vId1 = insertVehicle("Car 1");
+    const vId2 = insertVehicle("Car 2");
+    const fuelId = insertFuelLog(vId1);
+
+    // Try to delete vehicle 1's fuel log via vehicle 2's route
+    const res = await callDelete(vId2, fuelId);
+    expect(res.status).toBe(404);
+    expect(countFuelLogs()).toBe(1); // Not deleted
+  });
+
+  it("only deletes the targeted fuel log", async () => {
+    const vId = insertVehicle();
+    const fuelId1 = insertFuelLog(vId, "2026-01-10");
+    const fuelId2 = insertFuelLog(vId, "2026-01-20");
+    const fuelId3 = insertFuelLog(vId, "2026-01-30");
+    expect(countFuelLogs()).toBe(3);
+
+    const res = await callDelete(vId, fuelId2);
+    expect(res.status).toBe(200);
+    expect(countFuelLogs()).toBe(2);
+
+    // Verify the correct log was deleted
+    const remaining = sqlite
+      .prepare("SELECT id FROM fuel_logs ORDER BY id")
+      .all() as { id: number }[];
+    expect(remaining.map((r) => r.id)).toEqual([fuelId1, fuelId3]);
+  });
+});

--- a/src/app/api/e2e-cleanup/route.ts
+++ b/src/app/api/e2e-cleanup/route.ts
@@ -14,6 +14,9 @@ import {
   mealPlan,
   users,
   personalAccessTokens,
+  vehicles,
+  fuelLogs,
+  vehicleServices,
 } from "@/lib/db/schema";
 import { like, eq, inArray, sql } from "drizzle-orm";
 
@@ -30,6 +33,7 @@ const VALID_TYPES = [
   "meals",
   "users",
   "tokens",
+  "vehicles",
 ] as const;
 
 type CleanupType = (typeof VALID_TYPES)[number];
@@ -193,6 +197,27 @@ export async function POST(request: NextRequest) {
           .delete(personalAccessTokens)
           .where(like(personalAccessTokens.name, namePattern));
         deleted = result.changes ?? 0;
+        break;
+      }
+
+      case "vehicles": {
+        const matchingVehicles = await db
+          .select({ id: vehicles.id })
+          .from(vehicles)
+          .where(like(vehicles.name, namePattern));
+        if (matchingVehicles.length > 0) {
+          const vehicleIds = matchingVehicles.map((v) => v.id);
+          await db
+            .delete(fuelLogs)
+            .where(inArray(fuelLogs.vehicleId, vehicleIds));
+          await db
+            .delete(vehicleServices)
+            .where(inArray(vehicleServices.vehicleId, vehicleIds));
+          await db
+            .delete(vehicles)
+            .where(inArray(vehicles.id, vehicleIds));
+          deleted = matchingVehicles.length;
+        }
         break;
       }
 

--- a/src/app/api/vehicles/[id]/fuel/[fuelId]/route.ts
+++ b/src/app/api/vehicles/[id]/fuel/[fuelId]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { fuelLogs } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string; fuelId: string }> }
+) {
+  try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
+    const { id, fuelId } = await params;
+    const vehicleId = parseInt(id);
+    const fuelLogId = parseInt(fuelId);
+
+    const result = await db
+      .delete(fuelLogs)
+      .where(
+        and(eq(fuelLogs.id, fuelLogId), eq(fuelLogs.vehicleId, vehicleId))
+      );
+
+    if (result.changes === 0) {
+      return NextResponse.json(
+        { error: "Fuel log not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting fuel log:", error);
+    return NextResponse.json(
+      { error: "Failed to delete fuel log" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/vehicles/VehicleDetail.tsx
+++ b/src/components/vehicles/VehicleDetail.tsx
@@ -420,6 +420,9 @@ export function VehicleDetail({
   const [costSummary, setCostSummary] = useState<VehicleCostSummary | null>(
     null
   );
+  const [deletingFuelLogId, setDeletingFuelLogId] = useState<number | null>(
+    null
+  );
 
   useEffect(() => {
     if (vehicle && activeTab === "costs") {
@@ -436,6 +439,24 @@ export function VehicleDetail({
       setCostSummary(null);
     }
     onOpenChange(isOpen);
+  };
+
+  const handleDeleteFuelLog = async (logId: number) => {
+    if (!confirm("Delete this fuel log? This cannot be undone.")) return;
+    setDeletingFuelLogId(logId);
+    try {
+      const response = await fetch(
+        `/api/vehicles/${vehicle!.id}/fuel/${logId}`,
+        { method: "DELETE" }
+      );
+      if (response.ok) {
+        onRefresh?.();
+      }
+    } catch (error) {
+      console.error("Error deleting fuel log:", error);
+    } finally {
+      setDeletingFuelLogId(null);
+    }
   };
 
   if (!vehicle) return null;
@@ -687,12 +708,23 @@ export function VehicleDetail({
                             </p>
                           )}
                         </div>
-                        <Badge
-                          variant="secondary"
-                          className="bg-green-100 text-green-800 whitespace-nowrap"
-                        >
-                          ${log.costTotal.toFixed(2)}
-                        </Badge>
+                        <div className="flex items-center gap-1">
+                          <Badge
+                            variant="secondary"
+                            className="bg-green-100 text-green-800 whitespace-nowrap"
+                          >
+                            ${log.costTotal.toFixed(2)}
+                          </Badge>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-red-600"
+                            onClick={() => handleDeleteFuelLog(log.id)}
+                            disabled={deletingFuelLogId === log.id}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
- Add DELETE endpoint at `/api/vehicles/[id]/fuel/[fuelId]` with vehicle-scoped validation
- Add trash icon button to each fuel log entry in the Fuel tab with confirm dialog
- Add "vehicles" type to e2e-cleanup endpoint for test teardown

## Test plan
- [x] Unit: fuel log deletes successfully
- [x] Unit: returns 404 for non-existent fuel log
- [x] Unit: returns 404 when fuel log belongs to different vehicle
- [x] Unit: only deletes targeted fuel log, leaves others intact
- [x] E2e: create vehicle + fuel log, delete it, verify removal
- [x] Visual: delete button appears on fuel log entries - [proof](https://github.com/heuwels/tuis/pull/58#issuecomment-4279689230)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
