### PR TITLE
Add property income tracking for rental properties

### DIFF
--- a/src/app/api/__tests__/finance-equity.test.ts
+++ b/src/app/api/__tests__/finance-equity.test.ts
@@ -56,6 +56,18 @@ function createTables() {
       notes TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
+    CREATE TABLE IF NOT EXISTS property_income (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      property_id INTEGER NOT NULL REFERENCES properties(id),
+      date TEXT NOT NULL,
+      amount REAL NOT NULL,
+      category TEXT NOT NULL,
+      description TEXT,
+      tenant TEXT,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
   `);
 }
 

--- a/src/app/api/finance/properties/[id]/equity/route.ts
+++ b/src/app/api/finance/properties/[id]/equity/route.ts
@@ -5,6 +5,7 @@ import {
   mortgagePayments,
   propertyValuations,
   mortgageRates,
+  propertyIncome,
 } from "@/lib/db/schema";
 import { eq, asc, desc } from "drizzle-orm";
 import { format, addMonths, isBefore, startOfMonth } from "date-fns";
@@ -39,8 +40,8 @@ export async function GET(
 
     const property = propertyResult[0];
 
-    // Fetch all payments (ASC), all valuations (ASC), latest rate
-    const [payments, valuations, rates] = await Promise.all([
+    // Fetch all payments (ASC), all valuations (ASC), latest rate, all income (ASC)
+    const [payments, valuations, rates, incomeRecords] = await Promise.all([
       db
         .select()
         .from(mortgagePayments)
@@ -57,6 +58,11 @@ export async function GET(
         .where(eq(mortgageRates.propertyId, propertyId))
         .orderBy(desc(mortgageRates.effectiveDate))
         .limit(1),
+      db
+        .select()
+        .from(propertyIncome)
+        .where(eq(propertyIncome.propertyId, propertyId))
+        .orderBy(asc(propertyIncome.date)),
     ]);
 
     // Current value: latest valuation or purchase price
@@ -92,6 +98,29 @@ export async function GET(
     const avgMonthlyPayment =
       payments.length > 0 ? totalPaid / payments.length : 0;
 
+    // Income calculations
+    const totalIncome = incomeRecords.reduce((sum, i) => sum + i.amount, 0);
+    const totalCosts = totalPaid;
+    const netCashflow = totalIncome - totalCosts;
+
+    // Gross yield: annualize income if we have data spanning at least one month
+    let grossYield: number | null = null;
+    if (incomeRecords.length > 0 && currentValue > 0) {
+      const firstIncomeDate = new Date(incomeRecords[0].date);
+      const lastIncomeDate = new Date(incomeRecords[incomeRecords.length - 1].date);
+      const monthsOfData =
+        (lastIncomeDate.getFullYear() - firstIncomeDate.getFullYear()) * 12 +
+        (lastIncomeDate.getMonth() - firstIncomeDate.getMonth());
+      if (monthsOfData >= 1) {
+        const annualIncome = (totalIncome / monthsOfData) * 12;
+        grossYield = annualIncome / currentValue;
+      } else if (incomeRecords.length >= 1) {
+        // Less than a month of data but have records — annualize from count=1 month
+        const annualIncome = totalIncome * 12;
+        grossYield = annualIncome / currentValue;
+      }
+    }
+
     // Monthly timeline: one entry per month from first payment to now
     const monthlyTimeline: Array<{
       month: string;
@@ -99,6 +128,8 @@ export async function GET(
       cumulativePrincipal: number;
       loanBalance: number;
       equity: number;
+      income: number;
+      netCashflow: number;
     }> = [];
 
     if (payments.length > 0) {
@@ -132,12 +163,30 @@ export async function GET(
         const monthLoanBalance =
           property.loanAmountOriginal - cumulativePrincipal;
 
+        // Sum income for this month
+        let monthIncome = 0;
+        for (const inc of incomeRecords) {
+          if (inc.date.substring(0, 7) === monthStr) {
+            monthIncome += inc.amount;
+          }
+        }
+
+        // Sum payments for this month
+        let monthPayment = 0;
+        for (const p of payments) {
+          if (p.date.substring(0, 7) === monthStr) {
+            monthPayment += p.paymentAmount;
+          }
+        }
+
         monthlyTimeline.push({
           month: monthStr,
           estimatedValue,
           cumulativePrincipal,
           loanBalance: monthLoanBalance,
           equity: estimatedValue - monthLoanBalance,
+          income: monthIncome,
+          netCashflow: monthIncome - monthPayment,
         });
 
         currentMonth = addMonths(currentMonth, 1);
@@ -152,6 +201,10 @@ export async function GET(
       equityFromAppreciation,
       lvr,
       currentRate,
+      totalIncome,
+      totalCosts,
+      netCashflow,
+      grossYield,
       paymentSummary: {
         totalPaid,
         totalInterest,

--- a/src/app/api/finance/properties/[id]/income/[incomeId]/route.ts
+++ b/src/app/api/finance/properties/[id]/income/[incomeId]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { propertyIncome } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; incomeId: string }> }
+) {
+  try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
+    const { incomeId } = await params;
+    const incomeIdNum = parseInt(incomeId);
+    const body = await request.json();
+
+    const existing = await db
+      .select()
+      .from(propertyIncome)
+      .where(eq(propertyIncome.id, incomeIdNum))
+      .limit(1);
+
+    if (existing.length === 0) {
+      return NextResponse.json({ error: "Income not found" }, { status: 404 });
+    }
+
+    await db
+      .update(propertyIncome)
+      .set(body)
+      .where(eq(propertyIncome.id, incomeIdNum));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error updating property income:", error);
+    return NextResponse.json(
+      { error: "Failed to update property income" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; incomeId: string }> }
+) {
+  try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
+    const { incomeId } = await params;
+    const incomeIdNum = parseInt(incomeId);
+
+    await db
+      .delete(propertyIncome)
+      .where(eq(propertyIncome.id, incomeIdNum));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting property income:", error);
+    return NextResponse.json(
+      { error: "Failed to delete property income" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/finance/properties/[id]/income/route.ts
+++ b/src/app/api/finance/properties/[id]/income/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { propertyIncome } from "@/lib/db/schema";
+import { eq, and, desc, gte, lte } from "drizzle-orm";
+import { validateApiRequest } from "@/lib/auth/validate";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const propertyId = parseInt(id);
+
+    const { searchParams } = new URL(request.url);
+    const category = searchParams.get("category");
+    const from = searchParams.get("from");
+    const to = searchParams.get("to");
+
+    const conditions = [eq(propertyIncome.propertyId, propertyId)];
+    if (category) conditions.push(eq(propertyIncome.category, category));
+    if (from) conditions.push(gte(propertyIncome.date, from));
+    if (to) conditions.push(lte(propertyIncome.date, to));
+
+    const results = await db
+      .select()
+      .from(propertyIncome)
+      .where(and(...conditions))
+      .orderBy(desc(propertyIncome.date));
+
+    return NextResponse.json(results);
+  } catch (error) {
+    console.error("Error fetching property income:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch property income" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const authError = await validateApiRequest(request);
+    if (authError) return authError;
+
+    const { id } = await params;
+    const propertyId = parseInt(id);
+    const body = await request.json();
+    const { date, amount, category, description, tenant, notes } = body;
+
+    if (!date || amount === undefined || !category) {
+      return NextResponse.json(
+        { error: "date, amount, and category are required" },
+        { status: 400 }
+      );
+    }
+
+    const result = await db.insert(propertyIncome).values({
+      propertyId,
+      date,
+      amount,
+      category,
+      description: description || null,
+      tenant: tenant || null,
+      notes: notes || null,
+    });
+
+    return NextResponse.json(
+      { success: true, id: result.lastInsertRowid },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error creating property income:", error);
+    return NextResponse.json(
+      { error: "Failed to create property income" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/finance/EquityOverview.tsx
+++ b/src/components/finance/EquityOverview.tsx
@@ -22,6 +22,8 @@ interface TimelineEntry {
   cumulativePrincipal: number;
   loanBalance: number;
   equity: number;
+  income: number;
+  netCashflow: number;
 }
 
 interface EquityData {
@@ -32,6 +34,10 @@ interface EquityData {
   equityFromAppreciation: number;
   lvr: number | null;
   currentRate: number | null;
+  totalIncome: number;
+  totalCosts: number;
+  netCashflow: number;
+  grossYield: number | null;
   paymentSummary: {
     totalPaid: number;
     totalInterest: number;
@@ -150,10 +156,26 @@ export function EquityOverview({
       ? (equity.equityFromPrincipal / totalEquityBar) * 100
       : 50;
 
+  const hasIncome = equity.monthlyTimeline.some((e) => e.income > 0);
+  const activeTimelineMetrics: MetricConfig<TimelineEntry>[] = hasIncome
+    ? [
+        ...timelineMetrics,
+        {
+          key: "income",
+          getValue: (d: TimelineEntry) => d.income,
+          label: "Income",
+          color: "text-emerald-500",
+          dotColor: "bg-emerald-500",
+          strokeColor: "#10b981",
+          format: (v: number) => formatCurrency.format(v),
+        },
+      ]
+    : timelineMetrics;
+
   return (
     <div className="space-y-4">
       {/* Metric Cards */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
         <MetricCard
           label="Current Value"
           value={formatCurrency.format(equity.currentValue)}
@@ -181,6 +203,24 @@ export function EquityOverview({
           }
           color="amber"
         />
+        {equity.totalIncome > 0 && (
+          <MetricCard
+            label="Net Cashflow"
+            value={`${equity.netCashflow >= 0 ? "+" : ""}${formatCurrency.format(equity.netCashflow)}`}
+            color={equity.netCashflow >= 0 ? "green" : "red"}
+          />
+        )}
+        {equity.totalIncome > 0 && (
+          <MetricCard
+            label="Gross Yield"
+            value={
+              equity.grossYield !== null
+                ? `${(equity.grossYield * 100).toFixed(1)}%`
+                : "\u2014"
+            }
+            color="purple"
+          />
+        )}
       </div>
 
       {/* Equity Breakdown */}
@@ -218,7 +258,7 @@ export function EquityOverview({
         <div className="p-3 bg-gray-50 dark:bg-zinc-800 rounded-lg">
           <MultiLineChart
             data={equity.monthlyTimeline}
-            metrics={timelineMetrics}
+            metrics={activeTimelineMetrics}
             getLabel={(d) => formatMonth(d.month)}
             title="Equity Over Time"
           />

--- a/src/components/finance/PaymentsTab.tsx
+++ b/src/components/finance/PaymentsTab.tsx
@@ -20,11 +20,13 @@ import {
   CreditCard,
   Percent,
   TrendingUp,
+  DollarSign,
 } from "lucide-react";
 import {
   MortgagePayment,
   MortgageRate,
   PropertyValuation,
+  PropertyIncome,
 } from "@/types";
 
 function formatCurrency(amount: number): string {
@@ -58,6 +60,7 @@ export function PaymentsTab({ propertyId }: { propertyId: number | null }) {
       <MortgagePaymentsSection propertyId={propertyId} />
       <RateHistorySection propertyId={propertyId} />
       <ValuationsSection propertyId={propertyId} />
+      <IncomeSection propertyId={propertyId} />
     </div>
   );
 }
@@ -910,6 +913,391 @@ function ValuationFormDialog({
                 : valuation
                   ? "Save Changes"
                   : "Add Valuation"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// MARK: - Income Section
+
+function IncomeSection({ propertyId }: { propertyId: number }) {
+  const [income, setIncome] = useState<PropertyIncome[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<PropertyIncome | null>(null);
+
+  const fetchIncome = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/finance/properties/${propertyId}/income`
+      );
+      if (res.ok) setIncome(await res.json());
+    } catch (error) {
+      console.error("Error fetching income:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [propertyId]);
+
+  useEffect(() => {
+    fetchIncome();
+  }, [fetchIncome]);
+
+  const handleDelete = async (item: PropertyIncome) => {
+    if (!window.confirm("Delete this income record? This cannot be undone."))
+      return;
+    try {
+      const res = await fetch(
+        `/api/finance/properties/${propertyId}/income/${item.id}`,
+        { method: "DELETE" }
+      );
+      if (res.ok) fetchIncome();
+    } catch (error) {
+      console.error("Error deleting income:", error);
+    }
+  };
+
+  const totalIncome = income.reduce((sum, i) => sum + i.amount, 0);
+
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <DollarSign className="h-4 w-4 text-muted-foreground" />
+            <h3 className="font-semibold">Income</h3>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditing(null);
+              setFormOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            Add Income
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <p className="text-center text-muted-foreground py-4">Loading...</p>
+        ) : income.length === 0 ? (
+          <p className="text-center text-muted-foreground py-4">
+            No income recorded yet.
+          </p>
+        ) : (
+          <div className="border rounded-lg overflow-hidden bg-white dark:bg-zinc-900">
+            {/* Desktop header */}
+            <div className="hidden md:grid md:grid-cols-[100px_1fr_90px_1fr_1fr_80px] gap-2 px-4 py-2 bg-gray-50 dark:bg-zinc-800 border-b text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              <span>Date</span>
+              <span className="text-right">Amount</span>
+              <span>Category</span>
+              <span>Tenant</span>
+              <span>Description</span>
+              <span>Actions</span>
+            </div>
+
+            <div className="divide-y">
+              {income.map((item) => (
+                <div key={item.id}>
+                  {/* Desktop row */}
+                  <div className="hidden md:grid md:grid-cols-[100px_1fr_90px_1fr_1fr_80px] gap-2 px-4 py-3 items-center">
+                    <span className="text-xs text-muted-foreground">
+                      {format(parseISO(item.date), "d MMM yy")}
+                    </span>
+                    <span className="text-sm font-semibold text-right text-green-600 dark:text-green-400">
+                      {formatCurrency(item.amount)}
+                    </span>
+                    <span className="text-xs capitalize">{item.category}</span>
+                    <span className="text-xs text-muted-foreground truncate">
+                      {item.tenant || "—"}
+                    </span>
+                    <span className="text-xs text-muted-foreground truncate">
+                      {item.description || "—"}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        onClick={() => {
+                          setEditing(item);
+                          setFormOpen(true);
+                        }}
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-destructive hover:text-destructive"
+                        onClick={() => handleDelete(item)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Mobile row */}
+                  <div className="md:hidden px-4 py-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium text-green-600 dark:text-green-400">
+                          {formatCurrency(item.amount)}
+                        </p>
+                        <div className="flex items-center gap-2 mt-1">
+                          <span className="text-xs text-muted-foreground">
+                            {format(parseISO(item.date), "d MMM yy")}
+                          </span>
+                          <span className="text-xs capitalize">
+                            {item.category}
+                          </span>
+                          {item.tenant && (
+                            <span className="text-xs text-muted-foreground">
+                              {item.tenant}
+                            </span>
+                          )}
+                        </div>
+                        {item.description && (
+                          <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                            {item.description}
+                          </p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-0.5">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          onClick={() => {
+                            setEditing(item);
+                            setFormOpen(true);
+                          }}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive hover:text-destructive"
+                          onClick={() => handleDelete(item)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ))}
+
+              {/* Totals row */}
+              <div className="hidden md:grid md:grid-cols-[100px_1fr_90px_1fr_1fr_80px] gap-2 px-4 py-2 bg-gray-50 dark:bg-zinc-800 text-xs font-semibold">
+                <span>Total</span>
+                <span className="text-right text-green-600 dark:text-green-400">
+                  {formatCurrency(totalIncome)}
+                </span>
+                <span />
+                <span />
+                <span />
+                <span />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <IncomeFormDialog
+          propertyId={propertyId}
+          open={formOpen}
+          onOpenChange={(open) => {
+            setFormOpen(open);
+            if (!open) setEditing(null);
+          }}
+          income={editing}
+          onSave={fetchIncome}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+// MARK: - Income Form Dialog
+
+function IncomeFormDialog({
+  propertyId,
+  open,
+  onOpenChange,
+  income,
+  onSave,
+}: {
+  propertyId: number;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  income: PropertyIncome | null;
+  onSave: () => void;
+}) {
+  const [date, setDate] = useState("");
+  const [amount, setAmount] = useState("");
+  const [category, setCategory] = useState("rent");
+  const [description, setDescription] = useState("");
+  const [tenant, setTenant] = useState("");
+  const [notes, setNotes] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (income) {
+      setDate(income.date);
+      setAmount(income.amount.toString());
+      setCategory(income.category);
+      setDescription(income.description ?? "");
+      setTenant(income.tenant ?? "");
+      setNotes(income.notes ?? "");
+    } else {
+      setDate(new Date().toISOString().split("T")[0]);
+      setAmount("");
+      setCategory("rent");
+      setDescription("");
+      setTenant("");
+      setNotes("");
+    }
+  }, [income, open]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!date || !amount || !category) return;
+    setIsSaving(true);
+
+    try {
+      const url = income
+        ? `/api/finance/properties/${propertyId}/income/${income.id}`
+        : `/api/finance/properties/${propertyId}/income`;
+      const method = income ? "PUT" : "POST";
+
+      const body = {
+        date,
+        amount: parseFloat(amount),
+        category,
+        description: description.trim() || null,
+        tenant: tenant.trim() || null,
+        notes: notes.trim() || null,
+      };
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (response.ok) {
+        onOpenChange(false);
+        onSave();
+      }
+    } catch (error) {
+      console.error("Error saving income:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[450px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {income ? "Edit Income" : "Add Income"}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="inc-date">Date *</Label>
+              <Input
+                id="inc-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="inc-amount">Amount ($) *</Label>
+              <Input
+                id="inc-amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0.00"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="inc-category">Category *</Label>
+            <select
+              id="inc-category"
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              required
+            >
+              <option value="rent">Rent</option>
+              <option value="bond">Bond</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="inc-tenant">Tenant</Label>
+            <Input
+              id="inc-tenant"
+              value={tenant}
+              onChange={(e) => setTenant(e.target.value)}
+              placeholder="Tenant name"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="inc-description">Description</Label>
+            <Input
+              id="inc-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="e.g., Monthly rent payment"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="inc-notes">Notes</Label>
+            <Textarea
+              id="inc-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSaving || !date || !amount || !category}
+            >
+              {isSaving
+                ? "Saving..."
+                : income
+                  ? "Save Changes"
+                  : "Add Income"}
             </Button>
           </div>
         </form>

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -318,6 +318,19 @@ function initDb(): BetterSQLite3Database<typeof schema> {
       created_at TEXT DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
+
+    CREATE TABLE IF NOT EXISTS property_income (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      property_id INTEGER NOT NULL REFERENCES properties(id) ON DELETE CASCADE,
+      date TEXT NOT NULL,
+      amount REAL NOT NULL,
+      category TEXT NOT NULL,
+      description TEXT,
+      tenant TEXT,
+      notes TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
   `);
 
   // Add new columns if they don't exist (migrations for existing databases)

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -363,5 +363,20 @@ export type MortgagePayment = typeof mortgagePayments.$inferSelect;
 export type NewMortgagePayment = typeof mortgagePayments.$inferInsert;
 export type PropertyValuation = typeof propertyValuations.$inferSelect;
 export type NewPropertyValuation = typeof propertyValuations.$inferInsert;
+export const propertyIncome = sqliteTable("property_income", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  propertyId: integer("property_id").notNull().references(() => properties.id),
+  date: text("date").notNull(),
+  amount: real("amount").notNull(),
+  category: text("category").notNull(), // rent, bond, other
+  description: text("description"),
+  tenant: text("tenant"),
+  notes: text("notes"),
+  createdAt: text("created_at").default("CURRENT_TIMESTAMP"),
+  updatedAt: text("updated_at").default("CURRENT_TIMESTAMP"),
+});
+
 export type HouseholdExpense = typeof householdExpenses.$inferSelect;
 export type NewHouseholdExpense = typeof householdExpenses.$inferInsert;
+export type PropertyIncome = typeof propertyIncome.$inferSelect;
+export type NewPropertyIncome = typeof propertyIncome.$inferInsert;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -225,3 +225,16 @@ export interface HouseholdExpense {
 export interface HouseholdExpenseWithVendor extends HouseholdExpense {
   vendorName?: string | null;
 }
+
+export interface PropertyIncome {
+  id: number;
+  propertyId: number;
+  date: string;
+  amount: number;
+  category: string;
+  description: string | null;
+  tenant: string | null;
+  notes: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}


### PR DESCRIPTION
## Summary

- Add `property_income` table for tracking rental income (rent, bond, other)
- Add income CRUD API at `/api/finance/properties/[id]/income` with category/date filters
- Extend equity endpoint with `totalIncome`, `totalCosts`, `netCashflow`, `grossYield`, and per-month income/cashflow in timeline
- Add Income section to Payments tab with CRUD dialog (date, amount, category, tenant, description)
- Add conditional Net Cashflow and Gross Yield metric cards to equity overview (only shown when income exists)
- Add income line to equity timeline chart

## Test plan
- [x] 133 unit tests pass (including equity calculation with income table) — [proof](https://github.com/heuwels/tuis/pull/61#issuecomment-4285417544)
- [x] `npm run build` passes — [proof](https://github.com/heuwels/tuis/pull/61#issuecomment-4285417544)
- [x] Equity overview shows Net Cashflow and Gross Yield cards after adding income — [proof](https://github.com/heuwels/tuis/pull/61#issuecomment-4285416332)
- [x] Income section visible in Payments tab with CRUD — [proof](https://github.com/heuwels/tuis/pull/61#issuecomment-4285416590)
- [x] Timeline chart shows Income line — [proof](https://github.com/heuwels/tuis/pull/61#issuecomment-4285416332)

🤖 Generated with [Claude Code](https://claude.com/claude-code)