### PR TITLE
Replace hand-rolled charts with Recharts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-day-picker": "^9.13.0",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -4108,6 +4109,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -5385,7 +5422,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -5890,6 +5932,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -6050,6 +6155,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -7906,6 +8017,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -8028,6 +8260,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -9085,6 +9323,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -9619,6 +9867,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -10642,6 +10896,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10725,6 +10989,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -13382,6 +13655,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13787,7 +14061,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -13815,6 +14088,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-remove-scroll": {
@@ -13900,6 +14196,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -13912,6 +14238,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14012,6 +14353,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -15250,6 +15597,12 @@
         }
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -16360,6 +16713,15 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16401,6 +16763,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@sentry/nextjs": "^10",
     "@tailwindcss/typography": "^0.5.19",
     "better-sqlite3": "^12.5.0",
     "class-variance-authority": "^0.7.1",
@@ -38,7 +39,7 @@
     "react-day-picker": "^9.13.0",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
-    "@sentry/nextjs": "^10",
+    "recharts": "^3.8.1",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+import {
+  BarChart as RechartsBarChart,
+  Bar,
+  XAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
 interface BarChartProps<T> {
   data: T[];
   getKey: (d: T) => string;
@@ -8,6 +16,16 @@ interface BarChartProps<T> {
   formatLabel: (d: T) => string;
   barColor: string;
   label: string;
+}
+
+function ChartTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium">{label}</p>
+      <p className="text-muted-foreground">{payload[0].payload.formatted}</p>
+    </div>
+  );
 }
 
 export function BarChart<T>({
@@ -19,38 +37,39 @@ export function BarChart<T>({
   barColor,
   label,
 }: BarChartProps<T>) {
-  const values = data.map((d) => getValue(d) ?? 0);
-  const maxVal = Math.max(...values, 0.01);
+  const chartData = data.map((d) => {
+    const val = getValue(d) ?? 0;
+    return {
+      key: getKey(d),
+      name: formatLabel(d),
+      value: val,
+      formatted: val ? formatValue(val) : "\u2014",
+    };
+  });
 
   return (
     <div>
       <p className="text-sm font-medium mb-2">{label}</p>
-      <div className="flex items-end gap-1 h-28">
-        {data.map((d) => {
-          const val = getValue(d);
-          const height = val ? (val / maxVal) * 100 : 0;
-          return (
-            <div
-              key={getKey(d)}
-              className="flex-1 flex flex-col items-center gap-1 min-w-0"
-            >
-              <div className="w-full flex flex-col items-center justify-end h-24">
-                {val ? (
-                  <div
-                    className={`w-full ${barColor} rounded-t min-h-[4px]`}
-                    style={{ height: `${Math.max(height, 4)}%` }}
-                    title={`${formatLabel(d)}: ${formatValue(val)}`}
-                  />
-                ) : (
-                  <div className="w-full bg-gray-200 dark:bg-zinc-700 rounded-t h-[4px]" />
-                )}
-              </div>
-              <span className="text-[10px] text-muted-foreground truncate w-full text-center">
-                {formatLabel(d)}
-              </span>
-            </div>
-          );
-        })}
+      <div className="text-muted-foreground">
+        <ResponsiveContainer width="100%" height={160}>
+          <RechartsBarChart
+            data={chartData}
+            margin={{ top: 5, right: 5, bottom: 0, left: -10 }}
+          >
+            <XAxis
+              dataKey="name"
+              tick={{ fontSize: 11, fill: "currentColor" }}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <Tooltip
+              content={<ChartTooltip />}
+              cursor={{ fill: "currentColor", opacity: 0.08 }}
+            />
+            <Bar dataKey="value" fill={barColor} radius={[3, 3, 0, 0]} />
+          </RechartsBarChart>
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -18,7 +18,15 @@ interface BarChartProps<T> {
   label: string;
 }
 
-function ChartTooltip({ active, payload, label }: any) {
+function ChartTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: { payload: { formatted: string } }[];
+  label?: string;
+}) {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">

--- a/src/components/charts/MultiLineChart.tsx
+++ b/src/components/charts/MultiLineChart.tsx
@@ -26,13 +26,23 @@ interface MultiLineChartProps<T> {
   title: string;
 }
 
-function ChartTooltip({ active, payload, label, metrics }: any) {
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  metrics,
+}: {
+  active?: boolean;
+  payload?: { dataKey: string; payload: Record<string, number | null> }[];
+  label?: string;
+  metrics: MetricConfig<unknown>[];
+}) {
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
       <p className="font-medium mb-1">{label}</p>
-      {(metrics as MetricConfig<unknown>[]).map((m) => {
-        const entry = payload.find((p: any) => p.dataKey === m.key);
+      {metrics.map((m) => {
+        const entry = payload.find((p) => p.dataKey === m.key);
         const raw = entry?.payload[`${m.key}_raw`];
         if (raw == null) return null;
         return (
@@ -77,7 +87,7 @@ export function MultiLineChart<T>({
   });
 
   const chartData = data.map((d) => {
-    const point: Record<string, any> = { label: getLabel(d) };
+    const point: Record<string, string | number | null> = { label: getLabel(d) };
     metrics.forEach((m) => {
       const raw = m.getValue(d);
       point[`${m.key}_raw`] = raw;

--- a/src/components/charts/MultiLineChart.tsx
+++ b/src/components/charts/MultiLineChart.tsx
@@ -35,7 +35,7 @@ function ChartTooltip({
   active?: boolean;
   payload?: { dataKey: string; payload: Record<string, number | null> }[];
   label?: string;
-  metrics: MetricConfig<unknown>[];
+  metrics: MetricConfig<never>[];
 }) {
   if (!active || !payload?.length) return null;
   return (

--- a/src/components/charts/MultiLineChart.tsx
+++ b/src/components/charts/MultiLineChart.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
 export interface MetricConfig<T> {
   key: string;
   getValue: (d: T) => number | null;
@@ -17,6 +26,30 @@ interface MultiLineChartProps<T> {
   title: string;
 }
 
+function ChartTooltip({ active, payload, label, metrics }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium mb-1">{label}</p>
+      {(metrics as MetricConfig<unknown>[]).map((m) => {
+        const entry = payload.find((p: any) => p.dataKey === m.key);
+        const raw = entry?.payload[`${m.key}_raw`];
+        if (raw == null) return null;
+        return (
+          <div key={m.key} className="flex items-center gap-2">
+            <span
+              className={`w-2 h-2 rounded-full shrink-0 ${m.dotColor}`}
+            />
+            <span className="text-muted-foreground">
+              {m.label}: {m.format(raw)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export function MultiLineChart<T>({
   data,
   metrics,
@@ -25,103 +58,76 @@ export function MultiLineChart<T>({
 }: MultiLineChartProps<T>) {
   if (data.length < 2) return null;
 
-  const width = 500;
-  const height = 120;
-  const padding = { top: 10, right: 10, bottom: 20, left: 10 };
-  const chartW = width - padding.left - padding.right;
-  const chartH = height - padding.top - padding.bottom;
+  // Normalize each series independently to [0, 1] for overlay comparison
+  const seriesStats: Record<
+    string,
+    { min: number; max: number; range: number }
+  > = {};
+  metrics.forEach((m) => {
+    const nums = data
+      .map((d) => m.getValue(d))
+      .filter((v): v is number => v !== null);
+    if (nums.length === 0) {
+      seriesStats[m.key] = { min: 0, max: 1, range: 1 };
+    } else {
+      const min = Math.min(...nums);
+      const max = Math.max(...nums);
+      seriesStats[m.key] = { min, max, range: max - min || 1 };
+    }
+  });
 
-  const xStep = data.length > 1 ? chartW / (data.length - 1) : 0;
-
-  function normalizeSeries(values: (number | null)[]): (number | null)[] {
-    const nums = values.filter((v): v is number => v !== null);
-    if (nums.length === 0) return values;
-    const min = Math.min(...nums);
-    const max = Math.max(...nums);
-    const range = max - min || 1;
-    return values.map((v) => (v !== null ? (v - min) / range : null));
-  }
+  const chartData = data.map((d) => {
+    const point: Record<string, any> = { label: getLabel(d) };
+    metrics.forEach((m) => {
+      const raw = m.getValue(d);
+      point[`${m.key}_raw`] = raw;
+      const { min, range } = seriesStats[m.key];
+      point[m.key] = raw !== null ? (raw - min) / range : null;
+    });
+    return point;
+  });
 
   return (
     <div>
       <p className="text-sm font-medium mb-2">{title}</p>
-      <div className="flex gap-3 mb-2">
+      <div className="flex flex-wrap gap-x-3 gap-y-1 mb-2">
         {metrics.map((m) => (
           <div key={m.key} className="flex items-center gap-1">
             <div className={`w-2 h-2 rounded-full ${m.dotColor}`} />
-            <span className="text-[11px] text-muted-foreground">
-              {m.label}
-            </span>
+            <span className="text-[11px] text-muted-foreground">{m.label}</span>
           </div>
         ))}
       </div>
-      <svg
-        viewBox={`0 0 ${width} ${height}`}
-        className="w-full"
-        preserveAspectRatio="xMidYMid meet"
-      >
-        {/* X-axis labels */}
-        {data.map((d, i) => {
-          const step = Math.max(1, Math.floor(data.length / 6));
-          if (i % step !== 0 && i !== data.length - 1) return null;
-          return (
-            <text
-              key={getLabel(d)}
-              x={padding.left + i * xStep}
-              y={height - 2}
-              textAnchor="middle"
-              className="fill-muted-foreground"
-              fontSize="9"
-            >
-              {getLabel(d)}
-            </text>
-          );
-        })}
-
-        {/* Lines */}
-        {metrics.map((m) => {
-          const rawValues = data.map((d) => m.getValue(d));
-          const normalized = normalizeSeries(rawValues);
-
-          const points: { x: number; y: number; raw: number; idx: number }[] =
-            [];
-          normalized.forEach((v, i) => {
-            if (v !== null) {
-              points.push({
-                x: padding.left + i * xStep,
-                y: padding.top + chartH - v * chartH,
-                raw: rawValues[i]!,
-                idx: i,
-              });
-            }
-          });
-
-          if (points.length < 2) return null;
-
-          const pathD = points
-            .map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`)
-            .join(" ");
-
-          return (
-            <g key={m.key}>
-              <path
-                d={pathD}
-                fill="none"
+      <div className="text-muted-foreground">
+        <ResponsiveContainer width="100%" height={180}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 5, right: 10, bottom: 0, left: 10 }}
+          >
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: 11, fill: "currentColor" }}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis hide domain={[0, 1]} />
+            <Tooltip content={<ChartTooltip metrics={metrics} />} />
+            {metrics.map((m) => (
+              <Line
+                key={m.key}
+                type="monotone"
+                dataKey={m.key}
                 stroke={m.strokeColor}
-                strokeWidth="2"
-                strokeLinejoin="round"
+                strokeWidth={2}
+                dot={{ r: 3, fill: m.strokeColor }}
+                activeDot={{ r: 5 }}
+                connectNulls
               />
-              {points.map((p, i) => (
-                <circle key={i} cx={p.x} cy={p.y} r="2.5" fill={m.strokeColor}>
-                  <title>
-                    {getLabel(data[p.idx])}: {m.format(p.raw)}
-                  </title>
-                </circle>
-              ))}
-            </g>
-          );
-        })}
-      </svg>
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }

--- a/src/components/vehicles/FuelAnalytics.tsx
+++ b/src/components/vehicles/FuelAnalytics.tsx
@@ -247,7 +247,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
           getValue={(d) => d.totalSpend}
           formatValue={(v) => `$${v.toFixed(0)}`}
           formatLabel={(d) => formatMonth(d.month)}
-          barColor="bg-green-500"
+          barColor="#22c55e"
           label="Monthly Spend"
         />
       </div>
@@ -260,7 +260,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
           getValue={(d) => d.avgPricePerLitre}
           formatValue={(v) => `$${v.toFixed(3)}/L`}
           formatLabel={(d) => formatMonth(d.month)}
-          barColor="bg-red-400"
+          barColor="#f87171"
           label="Average Fuel Price ($/L)"
         />
       </div>
@@ -273,7 +273,7 @@ export function FuelAnalytics({ vehicleId }: { vehicleId: number }) {
           getValue={(d) => d.distanceKm}
           formatValue={(v) => `${v.toLocaleString()} km`}
           formatLabel={(d) => formatMonth(d.month)}
-          barColor="bg-blue-500"
+          barColor="#3b82f6"
           label="Distance per Month"
         />
       </div>


### PR DESCRIPTION
## Summary

- Replace hand-rolled SVG/CSS chart components with [Recharts](https://recharts.org/) for proper responsiveness, tooltips, and axis handling
- Fixes axis labels bleeding off screen, non-functional mobile tooltips, and charts not adapting to small viewports
- Preserves existing component interfaces (BarChart, MultiLineChart, MetricCard unchanged)

## What changed

| File | Change |
|---|---|
| `package.json` | Added `recharts` dependency |
| `BarChart.tsx` | Rewritten with Recharts `BarChart` + `ResponsiveContainer` |
| `MultiLineChart.tsx` | Rewritten with Recharts `LineChart`, keeps normalization for multi-scale overlay |
| `FuelAnalytics.tsx` | `barColor` props changed from Tailwind classes to hex colors |

## Test plan

### Desktop (1280px)

- [x] Bar charts render with proper axis labels and spacing

![Desktop fuel analytics](https://docs.lukeboyle.com/proof/2026-05-02/recharts-fuel-analytics-1f8a38b2.png)

- [x] Multi-line chart renders with legend and normalized series

![Equity timeline](https://docs.lukeboyle.com/proof/2026-05-02/recharts-equity-timeline-0394f3ce.png)

- [x] Tooltips show on hover with styled HTML (not native title)

![Tooltip proof](https://docs.lukeboyle.com/proof/2026-05-02/recharts-tooltip-proof-877fefa5.png)

### Mobile (375px)

- [x] Charts resize responsively, labels auto-thin to fit

![Mobile top](https://docs.lukeboyle.com/proof/2026-05-02/recharts-mobile-top-a5a773ab.png)

- [x] Multi-line chart and legend wrap correctly on small screens

![Mobile bottom](https://docs.lukeboyle.com/proof/2026-05-02/recharts-mobile-bottom-21079d9b.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
