### PR TITLE
Fix all 36 lint warnings

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -28,7 +28,7 @@ async function screenshot(page: Page, name: string) {
   });
 }
 
-async function screenshotFullPage(page: Page, name: string) {
+async function screenshotFullPage(page: Page, name: string) { // eslint-disable-line @typescript-eslint/no-unused-vars
   await page.screenshot({
     path: path.join(SCREENSHOT_DIR, `${name}.png`),
     fullPage: true,

--- a/src/app/api/__tests__/quotes.test.ts
+++ b/src/app/api/__tests__/quotes.test.ts
@@ -564,10 +564,6 @@ describe("Recent Completions API", () => {
     });
 
     it("returns completions from the current week", async () => {
-      const weekStart = format(
-        startOfWeek(new Date(), { weekStartsOn: 1 }),
-        "yyyy-MM-dd"
-      );
       const today = format(new Date(), "yyyy-MM-dd");
 
       const userResult = insertUser("Alice");

--- a/src/app/api/__tests__/setup.test.ts
+++ b/src/app/api/__tests__/setup.test.ts
@@ -132,7 +132,6 @@ describe("Setup API", () => {
 
   describe("GET /api/setup", () => {
     it("returns needsSetup: true when no users exist", async () => {
-      const req = makeRequest("/api/setup");
       const res = await setupRoute.GET();
       expect(res.status).toBe(200);
       const data = await res.json();

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,7 +3,7 @@ import Google from "next-auth/providers/google";
 import { db } from "@/lib/db";
 import { googleCalendarSettings } from "@/lib/db/schema";
 
-const { handlers, auth } = NextAuth({
+const { handlers } = NextAuth({
   providers: [
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,

--- a/src/app/api/e2e-cleanup/route.ts
+++ b/src/app/api/e2e-cleanup/route.ts
@@ -18,7 +18,7 @@ import {
   fuelLogs,
   vehicleServices,
 } from "@/lib/db/schema";
-import { like, eq, inArray, sql } from "drizzle-orm";
+import { like, inArray, sql } from "drizzle-orm";
 
 export const dynamic = "force-dynamic";
 
@@ -84,7 +84,7 @@ export async function POST(request: NextRequest) {
             .delete(completions)
             .where(inArray(completions.taskId, taskIds));
           // Delete tasks
-          const result = await db
+          await db
             .delete(tasks)
             .where(inArray(tasks.id, taskIds));
           deleted = matchingTasks.length;

--- a/src/app/api/quotes/route.ts
+++ b/src/app/api/quotes/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { quotes, vendors } from "@/lib/db/schema";
-import { eq, desc, sql } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/shopping/lists/route.ts
+++ b/src/app/api/shopping/lists/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { shoppingLists, shoppingItems } from "@/lib/db/schema";
-import { desc, eq, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/stats/recent-completions/route.ts
+++ b/src/app/api/stats/recent-completions/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { completions, tasks, users } from "@/lib/db/schema";
 import { eq, gte, desc } from "drizzle-orm";
-import { subDays, format, startOfWeek } from "date-fns";
+import { format, startOfWeek } from "date-fns";
 import { validateApiRequest } from "@/lib/auth/validate";
 
 export const dynamic = "force-dynamic";

--- a/src/app/api/tasks/[id]/complete/route.ts
+++ b/src/app/api/tasks/[id]/complete/route.ts
@@ -7,7 +7,6 @@ import {
   addWeeks,
   addMonths,
   format,
-  parseISO,
 } from "date-fns";
 import { syncTask } from "@/lib/calendar";
 import { validateApiRequest } from "@/lib/auth/validate";
@@ -52,7 +51,6 @@ export async function POST(
     const { id } = await params;
     const body = await request.json();
     const completedDateStr = body.completedDate || format(new Date(), "yyyy-MM-dd");
-    const completedDate = parseISO(completedDateStr);
     const vendorId = body.vendorId || null;
     const cost = body.cost || null;
     const completedBy = body.completedBy || null;

--- a/src/app/api/tasks/[id]/snooze/route.ts
+++ b/src/app/api/tasks/[id]/snooze/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { tasks } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
-import { addDays, addWeeks, format, parseISO } from "date-fns";
+import { addDays, addWeeks, format } from "date-fns";
 import { syncTask } from "@/lib/calendar";
 import { validateApiRequest } from "@/lib/auth/validate";
 

--- a/src/app/appliances/page.tsx
+++ b/src/app/appliances/page.tsx
@@ -85,6 +85,7 @@ export default function AppliancesPage() {
 
   useEffect(() => {
     fetchAppliances();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedLocation]);
 
   useEffect(() => {
@@ -92,6 +93,7 @@ export default function AppliancesPage() {
       fetchAppliances();
     }, 300);
     return () => clearTimeout(debounce);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
 
   const handleEdit = () => {

--- a/src/app/meals/page.tsx
+++ b/src/app/meals/page.tsx
@@ -101,6 +101,7 @@ function MealsContent() {
       setIsPickerOpen(true);
       window.history.replaceState({}, "", "/meals");
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 
   const handlePreviousWeek = () => {

--- a/src/app/quotes/page.tsx
+++ b/src/app/quotes/page.tsx
@@ -63,6 +63,7 @@ export default function QuotesPage() {
 
   useEffect(() => {
     fetchQuotes();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedStatus]);
 
   const pendingTotal = useMemo(

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -77,6 +77,7 @@ export default function ShoppingPage() {
 
   useEffect(() => {
     fetchLists();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/src/app/together/page.tsx
+++ b/src/app/together/page.tsx
@@ -77,6 +77,7 @@ export default function TogetherPage() {
 
   useEffect(() => {
     fetchActivities();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCategory, selectedStatus]);
 
   const handleActivityClick = (activity: Activity) => {

--- a/src/app/vehicles/page.tsx
+++ b/src/app/vehicles/page.tsx
@@ -54,6 +54,7 @@ export default function VehiclesPage() {
 
   useEffect(() => {
     fetchVehicles();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -61,6 +62,7 @@ export default function VehiclesPage() {
       fetchVehicles();
     }, 300);
     return () => clearTimeout(debounce);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
 
   const handleEdit = () => {

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -77,6 +77,7 @@ export default function VendorsPage() {
 
   useEffect(() => {
     fetchVendors();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCategory]);
 
   useEffect(() => {
@@ -84,6 +85,7 @@ export default function VendorsPage() {
       fetchVendors();
     }, 300);
     return () => clearTimeout(debounce);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
 
   const handleEdit = () => {

--- a/src/components/meals/MissingIngredients.tsx
+++ b/src/components/meals/MissingIngredients.tsx
@@ -62,6 +62,7 @@ export function MissingIngredients({
         setIsLoading(false)
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, startDate, endDate]);
 
   const fetchIngredients = async () => {

--- a/src/components/meals/RecipeCard.tsx
+++ b/src/components/meals/RecipeCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/card";
+import Image from "next/image";
 import { Clock, Users } from "lucide-react";
 import { resolveFileUrl } from "@/lib/file-url";
 
@@ -34,10 +35,12 @@ export function RecipeCard({ recipe, onClick }: RecipeCardProps) {
     >
       {recipe.imageUrl && (
         <div className="aspect-video relative bg-gray-100 dark:bg-gray-800">
-          <img
+          <Image
             src={resolveFileUrl(recipe.imageUrl) || ""}
             alt={recipe.name}
-            className="object-cover w-full h-full"
+            className="object-cover"
+            fill
+            unoptimized
           />
         </div>
       )}

--- a/src/components/meals/RecipeDetail.tsx
+++ b/src/components/meals/RecipeDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -59,8 +60,6 @@ export function RecipeDetail({
 }: RecipeDetailProps) {
   const [multiplier, setMultiplier] = useState(1);
   const [copied, setCopied] = useState(false);
-  const printRef = useRef<HTMLDivElement>(null);
-
   if (!recipe) return null;
 
   const totalTime = (recipe.prepTime || 0) + (recipe.cookTime || 0) || null;
@@ -152,7 +151,7 @@ export function RecipeDetail({
     const printWindow = window.open("", "_blank");
     if (!printWindow) return;
 
-    const text = formatRecipeAsText(
+    formatRecipeAsText(
       {
         name: recipe.name,
         prepTime: recipe.prepTime,
@@ -240,10 +239,12 @@ export function RecipeDetail({
 
         {recipe.imageUrl && (
           <div className="aspect-video relative bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden -mx-6">
-            <img
+            <Image
               src={resolveFileUrl(recipe.imageUrl) || ""}
               alt={recipe.name}
-              className="object-cover w-full h-full"
+              className="object-cover"
+              fill
+              unoptimized
             />
           </div>
         )}

--- a/src/components/meals/RecipeForm.tsx
+++ b/src/components/meals/RecipeForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -528,11 +529,13 @@ export function RecipeForm({
             ) : (
               <div>
                 {imageUrl && !imageUrl.startsWith("http") ? (
-                  <div className="relative rounded-lg overflow-hidden border bg-gray-50 dark:bg-zinc-900">
-                    <img
+                  <div className="relative rounded-lg overflow-hidden border bg-gray-50 dark:bg-zinc-900 h-32">
+                    <Image
                       src={resolveFileUrl(imageUrl) || ""}
                       alt="Recipe"
-                      className="w-full h-32 object-cover"
+                      className="object-cover"
+                      fill
+                      unoptimized
                     />
                     <button
                       type="button"

--- a/src/components/meals/RecipePicker.tsx
+++ b/src/components/meals/RecipePicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -150,11 +151,13 @@ export function RecipePicker({
 
             <div className="flex items-center gap-3 p-3 rounded-lg border bg-gray-50 dark:bg-zinc-900">
               {selectedRecipeForConfirm.imageUrl ? (
-                <div className="w-16 h-16 rounded overflow-hidden bg-gray-100 dark:bg-gray-800 flex-shrink-0">
-                  <img
+                <div className="w-16 h-16 rounded overflow-hidden bg-gray-100 dark:bg-gray-800 flex-shrink-0 relative">
+                  <Image
                     src={resolveFileUrl(selectedRecipeForConfirm.imageUrl) || ""}
                     alt={selectedRecipeForConfirm.name}
-                    className="object-cover w-full h-full"
+                    className="object-cover"
+                    fill
+                    unoptimized
                   />
                 </div>
               ) : (
@@ -238,11 +241,13 @@ export function RecipePicker({
                         onClick={() => handleRecipeClick(recipe)}
                       >
                         {recipe.imageUrl ? (
-                          <div className="w-16 h-16 rounded overflow-hidden bg-gray-100 dark:bg-gray-800 flex-shrink-0">
-                            <img
+                          <div className="w-16 h-16 rounded overflow-hidden bg-gray-100 dark:bg-gray-800 flex-shrink-0 relative">
+                            <Image
                               src={resolveFileUrl(recipe.imageUrl) || ""}
                               alt={recipe.name}
-                              className="object-cover w-full h-full"
+                              className="object-cover"
+                              fill
+                              unoptimized
                             />
                           </div>
                         ) : (

--- a/src/components/quotes/QuoteCard.tsx
+++ b/src/components/quotes/QuoteCard.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { QuoteWithVendor } from "@/types";
-import { DollarSign, Calendar, Wrench } from "lucide-react";
+import { Calendar, Wrench } from "lucide-react";
 import { format, parseISO } from "date-fns";
 
 interface QuoteCardProps {

--- a/src/components/quotes/QuoteDetail.tsx
+++ b/src/components/quotes/QuoteDetail.tsx
@@ -13,7 +13,6 @@ import {
   FileText,
   Wrench,
   Calendar,
-  DollarSign,
   Pencil,
   Trash2,
 } from "lucide-react";

--- a/src/components/together/ActivityCard.tsx
+++ b/src/components/together/ActivityCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -108,10 +109,12 @@ export function ActivityCard({ activity, onClick }: ActivityCardProps) {
     >
       {activity.imageUrl && (
         <div className="aspect-video relative bg-gray-100 dark:bg-gray-800">
-          <img
+          <Image
             src={activity.imageUrl}
             alt={activity.title}
-            className="object-cover w-full h-full"
+            className="object-cover"
+            fill
+            unoptimized
           />
         </div>
       )}

--- a/src/components/together/ActivityDetail.tsx
+++ b/src/components/together/ActivityDetail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -127,10 +128,12 @@ export function ActivityDetail({
 
         {activity.imageUrl && (
           <div className="aspect-video relative bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden -mx-6">
-            <img
+            <Image
               src={activity.imageUrl}
               alt={activity.title}
-              className="object-cover w-full h-full"
+              className="object-cover"
+              fill
+              unoptimized
             />
           </div>
         )}

--- a/src/components/vehicles/VehicleDetail.tsx
+++ b/src/components/vehicles/VehicleDetail.tsx
@@ -30,7 +30,6 @@ import {
 import {
   Car,
   Gauge,
-  Calendar,
   Pencil,
   Trash2,
   AlertTriangle,

--- a/src/lib/calendar/index.ts
+++ b/src/lib/calendar/index.ts
@@ -6,7 +6,7 @@ import {
   tasks,
   Task,
 } from "@/lib/db/schema";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 // Frequencies that should sync to Google Calendar
 const SYNCABLE_FREQUENCIES = [

--- a/src/lib/ingredients.ts
+++ b/src/lib/ingredients.ts
@@ -67,15 +67,6 @@ function toBase(amount: number, unit: IngredientUnit): number {
   return amount * entry.factor;
 }
 
-function fromBase(
-  baseAmount: number,
-  targetUnit: IngredientUnit
-): number {
-  const entry = TO_BASE[targetUnit];
-  if (!entry) return baseAmount;
-  return baseAmount / entry.factor;
-}
-
 /** Pick the best display unit for a base amount in a given group */
 function bestUnit(
   baseAmount: number,


### PR DESCRIPTION
## Summary
- Remove 18 unused imports/variables across API routes, components, and lib files
- Replace 7 `<img>` elements with `next/image` `<Image>` in recipe and activity components (using `fill` + `unoptimized` for user-uploaded images)
- Suppress 11 intentional `react-hooks/exhaustive-deps` warnings on mount/filter-change effects

Lint output goes from 36 warnings to 0. All 133 unit tests pass.

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 133/133 pass
- [ ] Verify recipe/activity images render correctly with `<Image>`
- [ ] Spot-check pages with filter-based data fetching (appliances, vehicles, vendors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)